### PR TITLE
Standardize authentication parameters to `token`

### DIFF
--- a/examples/basemap-preferences.html
+++ b/examples/basemap-preferences.html
@@ -1,3 +1,12 @@
+<!--
+
+To run this demo, you need to replace 'YOUR_ACCESS_TOKEN' with an access token from ArcGIS that has the correct privileges.
+
+To get started, sign up for a free ArcGIS Location Platform account or a free trial of ArcGIS Online and create developer credentials.
+
+https://developers.arcgis.com/documentation/security-and-authentication/get-started/
+
+-->
 <!DOCTYPE html>
 <html>
 
@@ -16,12 +25,10 @@
   <script src="../node_modules/maplibre-gl/dist/maplibre-gl.js"></script>
   <!-- Maplibre ArcGIS -->
   <script src="../dist/umd/maplibre-arcgis.min.js"></script>
-
 </head>
 
 <body>
   <div id="map"></div>
-  <script src="../debug/apikey.js"></script>
   <script>
 
     const map = new maplibregl.Map({
@@ -30,9 +37,11 @@
       center: [-88.805, 30.027], // starting location
     });
 
+    const apiKey = 'YOUR_ACCESS_TOKEN';
+
     const basemapStyle = maplibreArcGIS.BasemapStyle.applyStyle(map,{
       style: 'arcgis/outdoor',
-      token: apiKey
+      token: apiKey // ArcGIS API key
     });
 
     map.on("load", () => {

--- a/examples/basemap-self.html
+++ b/examples/basemap-self.html
@@ -1,3 +1,12 @@
+<!--
+
+To run this demo, you need to replace 'YOUR_ACCESS_TOKEN' with an access token from ArcGIS that has the correct privileges.
+
+To get started, sign up for a free ArcGIS Location Platform account or a free trial of ArcGIS Online and create developer credentials.
+
+https://developers.arcgis.com/documentation/security-and-authentication/get-started/
+
+-->
 <!DOCTYPE html>
 <html>
 
@@ -21,7 +30,6 @@
 
 <body>
   <div id="map"></div>
-  <script src="../debug/apikey.js"></script>
   <script type="module">
 
     const map = new maplibregl.Map({
@@ -30,7 +38,12 @@
       center: [-117.805, 34.027], // starting location [longitude, latitude]
     });
 
+    const apiKey = 'YOUR_ACCESS_TOKEN';
+
+    // Make self request
     const selfResponse = await maplibreArcGIS.BasemapStyle.getSelf();
+
+    // Process self request
     const styleNames = selfResponse.styles;
     const languageOptions = selfResponse.languages;
 

--- a/examples/basemap-session.html
+++ b/examples/basemap-session.html
@@ -1,3 +1,12 @@
+<!--
+
+To run this demo, you need to replace 'YOUR_ACCESS_TOKEN' with an access token from ArcGIS that has the correct privileges.
+
+To get started, sign up for a free ArcGIS Location Platform account or a free trial of ArcGIS Online and create developer credentials.
+
+https://developers.arcgis.com/documentation/security-and-authentication/get-started/
+
+-->
 <!DOCTYPE html>
 <html>
 
@@ -16,22 +25,23 @@
   <script src="../node_modules/maplibre-gl/dist/maplibre-gl.js"></script>
   <!-- Maplibre ArcGIS -->
   <script src="../dist/umd/maplibre-arcgis.min.js"></script>
-
 </head>
 
 <body>
   <div id="map"></div>
-  <script src="../debug/apikey.js"></script>
   <script type="module">
+
     const map = new maplibregl.Map({
       container: "map", // the id of the div element
       zoom: 14, // starting zoom
       center: [-117.805, 34.027], // starting location
     });
 
+    const apiKey = 'YOUR_ACCESS_TOKEN';
+
     const basemapSession = await maplibreArcGIS.BasemapSession.start({
       styleFamily: 'arcgis',
-      token: sessionKey2,
+      token: apiKey, // ArcGIS API key
       duration:30, // Only valid for 30 seconds, for testing
       autoRefresh: true
     });

--- a/examples/basemap-style.html
+++ b/examples/basemap-style.html
@@ -1,3 +1,12 @@
+<!--
+
+To run this demo, you need to replace 'YOUR_ACCESS_TOKEN' with an access token from ArcGIS that has the correct privileges.
+
+To get started, sign up for a free ArcGIS Location Platform account or a free trial of ArcGIS Online and create developer credentials.
+
+https://developers.arcgis.com/documentation/security-and-authentication/get-started/
+
+-->
 <!DOCTYPE html>
 <html>
 
@@ -16,22 +25,22 @@
   <script src="../node_modules/maplibre-gl/dist/maplibre-gl.js"></script>
   <!-- Maplibre ArcGIS -->
   <script src="../dist/umd/maplibre-arcgis.min.js"></script>
-
 </head>
 
 <body>
   <div id="map"></div>
-  <script src="../debug/apikey.js"></script>
   <script>
 
-    // Also supports item IDs for custom basemap styles
-    // Try: '9d94a890b76a417cad8a748df4f97336'
     const map = new maplibregl.Map({
       container: "map", // the id of the div element
       zoom: 5, // starting zoom
       center: [138.2529, 36.2048], // starting location
     });
 
+    const apiKey = 'YOUR_ACCESS_TOKEN';
+
+    // Also supports item IDs for custom basemap styles
+    // Try: '9d94a890b76a417cad8a748df4f97336'
     const basemapStyle = maplibreArcGIS.BasemapStyle.applyStyle(map, {
       style: 'arcgis/imagery',
       token: apiKey

--- a/examples/esm-basemap.html
+++ b/examples/esm-basemap.html
@@ -1,3 +1,12 @@
+<!--
+
+To run this demo, you need to replace 'YOUR_ACCESS_TOKEN' with an access token from ArcGIS that has the correct privileges.
+
+To get started, sign up for a free ArcGIS Location Platform account or a free trial of ArcGIS Online and create developer credentials.
+
+https://developers.arcgis.com/documentation/security-and-authentication/get-started/
+
+-->
 <!DOCTYPE html>
 <html>
 
@@ -20,8 +29,8 @@
       }
     }
   </script>
-  <script src="../debug/apikey.js"></script>
 </head>
+
 <body>
   <div id="map"></div>
 
@@ -35,6 +44,8 @@
       center: [-118.498, 34.014], // starting location [longitude, latitude]
       attributionControl: false
     });
+
+    const apiKey = 'YOUR_ACCESS_TOKEN';
 
     const arcgisBasemap = BasemapStyle.applyStyle(map, {
       style: 'arcgis/navigation',

--- a/examples/esri-attribution.html
+++ b/examples/esri-attribution.html
@@ -1,3 +1,12 @@
+<!--
+
+To run this demo, you need to replace 'YOUR_ACCESS_TOKEN' with an access token from ArcGIS that has the correct privileges.
+
+To get started, sign up for a free ArcGIS Location Platform account or a free trial of ArcGIS Online and create developer credentials.
+
+https://developers.arcgis.com/documentation/security-and-authentication/get-started/
+
+-->
 <!DOCTYPE html>
 <html>
 
@@ -16,13 +25,13 @@
   <script src="../node_modules/maplibre-gl/dist/maplibre-gl.js"></script>
   <!-- MapLibre ArcGIS -->
   <script src="../dist/umd/maplibre-arcgis.min.js"></script>
-
 </head>
 
 <body>
   <div id="map"></div>
-  <script src="../debug/apikey.js"></script>
   <script>
+
+    const apiKey = 'YOUR_ACCESS_TOKEN';
 
     const styleUrl = maplibreArcGIS.BasemapStyle.url({
       style: 'arcgis/streets',

--- a/examples/feature-layer-cluster.html
+++ b/examples/feature-layer-cluster.html
@@ -1,3 +1,12 @@
+<!--
+
+To run this demo, you need to replace 'YOUR_ACCESS_TOKEN' with an access token from ArcGIS that has the correct privileges.
+
+To get started, sign up for a free ArcGIS Location Platform account or a free trial of ArcGIS Online and create developer credentials.
+
+https://developers.arcgis.com/documentation/security-and-authentication/get-started/
+
+-->
 <!DOCTYPE html>
 <html>
 
@@ -16,13 +25,13 @@
   <script src="../node_modules/maplibre-gl/dist/maplibre-gl.js"></script>
   <!-- Maplibre ArcGIS -->
   <script src="../dist/umd/maplibre-arcgis.min.js"></script>
-
 </head>
 
 <body>
   <div id="map"></div>
-  <script src="../debug/apikey.js"></script>
   <script>
+
+    const apiKey = 'YOUR_ACCESS_TOKEN';
 
     const map = new maplibregl.Map({
       container: "map", // the id of the div element

--- a/examples/feature-layer-styled.html
+++ b/examples/feature-layer-styled.html
@@ -1,3 +1,12 @@
+<!--
+
+To run this demo, you need to replace 'YOUR_ACCESS_TOKEN' with an access token from ArcGIS that has the correct privileges.
+
+To get started, sign up for a free ArcGIS Location Platform account or a free trial of ArcGIS Online and create developer credentials.
+
+https://developers.arcgis.com/documentation/security-and-authentication/get-started/
+
+-->
 <!DOCTYPE html>
 <html>
 
@@ -16,12 +25,10 @@
   <script src="../node_modules/maplibre-gl/dist/maplibre-gl.js"></script>
   <!-- Maplibre ArcGIS -->
   <script src="../dist/umd/maplibre-arcgis.min.js"></script>
-
 </head>
 
 <body>
   <div id="map"></div>
-  <script src="../debug/apikey.js"></script>
   <script>
 
     const map = new maplibregl.Map({
@@ -29,6 +36,9 @@
       zoom: 12, // starting zoom
       center: [-118.805, 34.027], // starting location [longitude, latitude]
     });
+
+    const apiKey = 'YOUR_ACCESS_TOKEN';
+
     const basemapStyle = maplibreArcGIS.BasemapStyle.applyStyle(map, {
       style: 'arcgis/light-gray',
       token: apiKey,

--- a/examples/feature-layer.html
+++ b/examples/feature-layer.html
@@ -1,3 +1,12 @@
+<!--
+
+To run this demo, you need to replace 'YOUR_ACCESS_TOKEN' with an access token from ArcGIS that has the correct privileges.
+
+To get started, sign up for a free ArcGIS Location Platform account or a free trial of ArcGIS Online and create developer credentials.
+
+https://developers.arcgis.com/documentation/security-and-authentication/get-started/
+
+-->
 <!DOCTYPE html>
 <html>
 
@@ -16,12 +25,10 @@
   <script src="../node_modules/maplibre-gl/dist/maplibre-gl.js"></script>
   <!-- Maplibre ArcGIS -->
   <script src="../dist/umd/maplibre-arcgis.min.js"></script>
-
 </head>
 
 <body>
   <div id="map"></div>
-  <script src="../debug/apikey.js"></script>
   <script>
 
     const map = new maplibregl.Map({
@@ -29,6 +36,9 @@
       zoom: 12, // starting zoom
       center: [-118.805, 34.027], // starting location [longitude, latitude]
     });
+
+    const apiKey = 'YOUR_ACCESS_TOKEN';
+
     const basemapStyle = maplibreArcGIS.BasemapStyle.applyStyle(map, {
       style: 'arcgis/outdoor',
       token: apiKey

--- a/examples/feature-multilayer.html
+++ b/examples/feature-multilayer.html
@@ -1,3 +1,12 @@
+<!--
+
+To run this demo, you need to replace 'YOUR_ACCESS_TOKEN' with an access token from ArcGIS that has the correct privileges.
+
+To get started, sign up for a free ArcGIS Location Platform account or a free trial of ArcGIS Online and create developer credentials.
+
+https://developers.arcgis.com/documentation/security-and-authentication/get-started/
+
+-->
 <!DOCTYPE html>
 <html>
 
@@ -16,12 +25,10 @@
   <script src="../node_modules/maplibre-gl/dist/maplibre-gl.js"></script>
   <!-- Maplibre ArcGIS -->
   <script src="../dist/umd/maplibre-arcgis.min.js"></script>
-
 </head>
 
 <body>
   <div id="map"></div>
-  <script src="../debug/apikey.js"></script>
   <script>
 
     const map = new maplibregl.Map({
@@ -29,6 +36,9 @@
       zoom: 6, // starting zoom
       center: [-120.504, 50.925] // starting location [longitude, latitude]
     });
+
+    const apiKey = 'YOUR_ACCESS_TOKEN';
+
     const basemapStyle = maplibreArcGIS.BasemapStyle.applyStyle(map, {
       style: 'arcgis/outdoor',
       token: apiKey

--- a/examples/vector-tile-layer-only.html
+++ b/examples/vector-tile-layer-only.html
@@ -16,7 +16,6 @@
   <script src="../node_modules/maplibre-gl/dist/maplibre-gl.js"></script>
   <!-- Maplibre ArcGIS -->
   <script src="../dist/umd/maplibre-arcgis.min.js"></script>
-
 </head>
 
 <body>

--- a/examples/vector-tile-layer-styled.html
+++ b/examples/vector-tile-layer-styled.html
@@ -1,3 +1,12 @@
+<!--
+
+To run this demo, you need to replace 'YOUR_ACCESS_TOKEN' with an access token from ArcGIS that has the correct privileges.
+
+To get started, sign up for a free ArcGIS Location Platform account or a free trial of ArcGIS Online and create developer credentials.
+
+https://developers.arcgis.com/documentation/security-and-authentication/get-started/
+
+-->
 <!DOCTYPE html>
 <html>
 
@@ -21,13 +30,15 @@
 
 <body>
   <div id="map"></div>
-  <script src="../debug/apikey.js"></script>
   <script type="module">
     const map = new maplibregl.Map({
       container: "map", // the id of the div element
       zoom: 13, // starting zoom
       center: [-118.498, 34.014], // starting location [longitude, latitude]
     });
+
+    const apiKey = 'YOUR_ACCESS_TOKEN';
+
     const basemapStyle = maplibreArcGIS.BasemapStyle.applyStyle(map, {
       style: 'arcgis/light-gray',
       token: apiKey

--- a/examples/vector-tile-layer.html
+++ b/examples/vector-tile-layer.html
@@ -1,3 +1,12 @@
+<!--
+
+To run this demo, you need to replace 'YOUR_ACCESS_TOKEN' with an access token from ArcGIS that has the correct privileges.
+
+To get started, sign up for a free ArcGIS Location Platform account or a free trial of ArcGIS Online and create developer credentials.
+
+https://developers.arcgis.com/documentation/security-and-authentication/get-started/
+
+-->
 <!DOCTYPE html>
 <html>
 
@@ -16,15 +25,13 @@
   <script src="../node_modules/maplibre-gl/dist/maplibre-gl.js"></script>
   <!-- Maplibre ArcGIS -->
   <script src="../dist/umd/maplibre-arcgis.min.js"></script>
-
 </head>
 
 <body>
   <div id="map"></div>
-  <script src="../debug/apikey.js"></script>
   <script type="module">
 
-    const basemapsKey = apiKey;
+    const apiKey = 'YOUR_ACCESS_TOKEN';
 
     const map = new maplibregl.Map({
       container: "map", // the id of the div element

--- a/src/BasemapStyle.ts
+++ b/src/BasemapStyle.ts
@@ -131,6 +131,10 @@ export interface IUpdateStyleOptions {
    */
   style?: string;
   /**
+   * A new ArcGIS access token. This will override the existing token.
+   */
+  token?: string;
+  /**
    * Set style preferences including language, worldview, and places.
    */
   preferences?: IBasemapPreferences;
@@ -283,7 +287,7 @@ export class BasemapStyle {
    */
   async updateStyle(options: IUpdateStyleOptions): Promise<StyleSpecification> {
     if (options.style) this.styleId = options.style;
-
+    if (options.token) this.token = options.token;
     if (options.preferences) {
       this._updatePreferences(options.preferences);
     }

--- a/src/BasemapStyle.ts
+++ b/src/BasemapStyle.ts
@@ -1,4 +1,4 @@
-import { request, ApiKeyManager, type ArcGISIdentityManager } from '@esri/arcgis-rest-request';
+import { request } from '@esri/arcgis-rest-request';
 import type { Map, StyleOptions, StyleSpecification, StyleSwapOptions, VectorTileSource } from 'maplibre-gl';
 import mitt, { type Emitter } from 'mitt';
 import { AttributionControl, type IAttributionControlOptions } from './AttributionControl';

--- a/src/HostedLayer.ts
+++ b/src/HostedLayer.ts
@@ -96,7 +96,9 @@ export abstract class HostedLayer {
   /**
    * An ArcGIS access token is required for accessing secure data layers. To get a token, go to the [Security and Authentication Guide](https://developers.arcgis.com/documentation/security-and-authentication/get-started/).
    */
-  authentication?: RestJSAuthenticationManager | string;
+  token: string;
+
+  protected _authentication?: RestJSAuthenticationManager;
 
   /**
    * Prevent public constructor from appearing in docs by making it protected.
@@ -105,11 +107,6 @@ export abstract class HostedLayer {
   protected constructor() {
     // intentionally empty
     if (new.target === HostedLayer) throw new Error('HostedLayer is an abstract class and cannot be instantiated directly.');
-  }
-
-  protected get token(): string {
-    if (!this.authentication) return undefined;
-    return typeof this.authentication === 'string' ? this.authentication : this.authentication.token;
   }
 
   /**

--- a/src/Util.ts
+++ b/src/Util.ts
@@ -94,6 +94,7 @@ export const warn = (...args: any[]) => {
 };
 
 export const checkAccessTokenType = (token: string): 'user' | 'app' | 'basemapSession' => {
+  if (!token || token.length === 0) return null;
   // API key case -- also catches app tokens w/ personal privileges
   const apiKeyPrefixes = ['AAPT', 'AAPK', 'AATK'];
   for (const prefix of apiKeyPrefixes) if (token.startsWith(prefix)) return 'app';
@@ -110,7 +111,7 @@ export const checkAccessTokenType = (token: string): 'user' | 'app' | 'basemapSe
   return 'app';
 };
 export const wrapAccessToken = async (token: string): Promise<ApiKeyManager | ArcGISIdentityManager> => {
-  if (!token) return null;
+  if (!token || token.length === 0) return null;
   const tokenType = checkAccessTokenType(token);
   // User tokens
   if (tokenType === 'user') return await ArcGISIdentityManager.fromToken({ token: token });

--- a/src/Util.ts
+++ b/src/Util.ts
@@ -1,4 +1,4 @@
-import type { ApiKeyManager, ApplicationCredentialsManager, ArcGISIdentityManager } from '@esri/arcgis-rest-request';
+import { ApiKeyManager, ArcGISIdentityManager, type ApplicationCredentialsManager } from '@esri/arcgis-rest-request';
 
 /**
  * Custom type to represent authentication managers used in ArcGIS REST JS.
@@ -91,6 +91,33 @@ export const warn = (...args: any[]) => {
   if (console && console.warn) {
     console.warn.apply(console, args);
   }
+};
+
+export const checkAccessTokenType = (token: string): 'user' | 'app' | 'basemapSession' => {
+  // API key case -- also catches app tokens w/ personal privileges
+  const apiKeyPrefixes = ['AAPT', 'AAPK', 'AATK'];
+  for (const prefix of apiKeyPrefixes) if (token.startsWith(prefix)) return 'app';
+
+  // Session token for basemaps
+  const sessionTokenPrefixes = ['AAST'];
+  for (const prefix of sessionTokenPrefixes) if (token.startsWith(prefix)) return 'basemapSession';
+
+  // OAuth 2.0 style token
+  if (token.length == 256) return 'user';
+  else if (token.length === 128) return 'app'; // treated identically to API key
+
+  // Token type not recognized; default to 'app'
+  return 'app';
+};
+export const wrapAccessToken = async (token: string): Promise<ApiKeyManager | ArcGISIdentityManager> => {
+  if (!token) return null;
+  const tokenType = checkAccessTokenType(token);
+  // User tokens
+  if (tokenType === 'user') return await ArcGISIdentityManager.fromToken({ token: token });
+  // Session tokens
+  else if (tokenType === 'basemapSession') return ApiKeyManager.fromKey(token);
+  // API keys, app tokens
+  else return ApiKeyManager.fromKey(token);
 };
 /*
  * Copyright 2025 Esri

--- a/src/VectorTileLayer.ts
+++ b/src/VectorTileLayer.ts
@@ -2,7 +2,7 @@ import { getItem, getItemResource, getItemResources } from '@esri/arcgis-rest-po
 import { request } from '@esri/arcgis-rest-request';
 import type { LayerSpecification, StyleSpecification, VectorSourceSpecification } from '@maplibre/maplibre-gl-style-spec';
 import { type IDataServiceInfo, type IHostedLayerOptions, type IItemInfo, HostedLayer } from './HostedLayer';
-import { checkItemId, checkServiceUrlType, cleanUrl, isRelativePath, parseRelativeUrl, toCdnUrl, warn } from './Util';
+import { checkItemId, checkServiceUrlType, cleanUrl, isRelativePath, parseRelativeUrl, toCdnUrl, warn, wrapAccessToken } from './Util';
 
 export interface IVectorTileServiceDefinition {
   tiles: string[];
@@ -53,8 +53,7 @@ export class VectorTileLayer extends HostedLayer {
 
     if (!options || !(options.itemId || options.url)) throw new Error('Vector tile layer requires either an \'itemId\' or \'url\'.');
 
-    if (options.authentication) this.authentication = options.authentication;
-    else if (options.token) this.authentication = options.token;
+    if (options.token) this.token = options.token;
 
     if (options.attribution) this._customAttribution = options.attribution;
 
@@ -90,6 +89,8 @@ export class VectorTileLayer extends HostedLayer {
   async _loadStyle(): Promise<StyleSpecification> {
     let styleInfo: StyleSpecification | null = null;
 
+    this._authentication = await wrapAccessToken(this.token);
+
     let styleSource = this._inputType;
     switch (styleSource) {
       case 'ItemId': {
@@ -117,7 +118,7 @@ export class VectorTileLayer extends HostedLayer {
 
   async _loadStyleFromItemId(): Promise<StyleSpecification | null> {
     const params = {
-      authentication: this.authentication,
+      authentication: this._authentication,
       portal: this._itemInfo.portalUrl,
     };
     // Load style info
@@ -162,7 +163,7 @@ export class VectorTileLayer extends HostedLayer {
     if (!this._serviceInfo.styleEndpoint) this._serviceInfo.styleEndpoint = 'resources/styles/';
 
     const styleInfo = (await request(`${this._serviceInfo.serviceUrl}${this._serviceInfo.styleEndpoint}`, {
-      authentication: this.authentication,
+      authentication: this._authentication,
     })) as StyleSpecification;
     return styleInfo;
   }
@@ -172,7 +173,7 @@ export class VectorTileLayer extends HostedLayer {
    */
   async _loadServiceInfo(): Promise<IVectorTileServiceInfo> {
     const serviceResponse = (await request(this._serviceInfo.serviceUrl, {
-      authentication: this.authentication,
+      authentication: this._authentication,
     })) as IVectorTileServiceDefinition;
 
     this._serviceInfo = {
@@ -190,7 +191,7 @@ export class VectorTileLayer extends HostedLayer {
    */
   async _loadItemInfo(): Promise<IItemInfo> {
     const itemResponse = await getItem(this._itemInfo.itemId, {
-      authentication: this.authentication,
+      authentication: this._authentication,
       portal: this._itemInfo.portalUrl,
     });
 
@@ -226,7 +227,7 @@ export class VectorTileLayer extends HostedLayer {
     if (style.glyphs) {
       if (isRelativePath(style.glyphs)) style.glyphs = parseRelativeUrl(style.glyphs, styleUrl);
       style.glyphs = toCdnUrl(style.glyphs);
-      if (this.authentication) style.glyphs = `${style.glyphs}?token=${this.token}`;
+      if (this._authentication) style.glyphs = `${style.glyphs}?token=${this._authentication.token}`;
     }
 
     // Validate sprite
@@ -238,13 +239,13 @@ export class VectorTileLayer extends HostedLayer {
           if (isRelativePath(sprite.url)) sprite.url = parseRelativeUrl(sprite.url, styleUrl);
           sprite.url = toCdnUrl(sprite.url);
 
-          if (this.authentication) sprite.url = `${sprite.url}?token=${this.token}`;
+          if (this._authentication) sprite.url = `${sprite.url}?token=${this._authentication.token}`;
         }
       }
       else {
         if (isRelativePath(style.sprite)) style.sprite = parseRelativeUrl(style.sprite, styleUrl);
         style.sprite = toCdnUrl(style.sprite);
-        if (this.authentication) style.sprite = `${style.sprite}?token=${this.token}`;
+        if (this._authentication) style.sprite = `${style.sprite}?token=${this._authentication.token}`;
       }
     }
 
@@ -272,9 +273,9 @@ export class VectorTileLayer extends HostedLayer {
       }
 
       // Provide authentication
-      if (this.authentication) {
-        if (source.url) source.url = `${source.url}?token=${this.token}`;
-        if (source.tiles) source.tiles = source.tiles.map(tileUrl => `${tileUrl}?token=${this.token}`);
+      if (this._authentication) {
+        if (source.url) source.url = `${source.url}?token=${this._authentication.token}`;
+        if (source.tiles) source.tiles = source.tiles.map(tileUrl => `${tileUrl}?token=${this._authentication.token}`);
       }
 
       // Provide attribution


### PR DESCRIPTION
Standardize all auth parameters to `token`, and wrap access tokens for all REST requests to prevent warnings.

- Simplify API when using API keys
- Remove the requirement to import REST JS libraries, only required for AGO user auth scenarios