### PR TITLE
Layer loading refactor

### DIFF
--- a/src/FeatureLayer.ts
+++ b/src/FeatureLayer.ts
@@ -125,12 +125,9 @@ export type SupportedInputTypes = 'ItemId' | 'FeatureService' | 'FeatureLayer';
  * parks.addSourcesAndLayersTo(map);
  * ```
  */
-export type InternalSourceSpecification = Omit<GeoJSONSourceSpecification, 'data'> & {
-  data: () => GeoJSON.GeoJSON;
-};
 
 export class FeatureLayer extends HostedLayer {
-  declare protected _sources: { [_: string]: InternalSourceSpecification };
+  declare protected _sources: { [_: string]: GeoJSONSourceSpecification };
   private _featureLayerSourceManagers: { [_: string]: FeatureLayerSourceManager };
 
   declare protected _layers: LayerSpecification[];
@@ -212,9 +209,9 @@ export class FeatureLayer extends HostedLayer {
       url: layerUrl,
       httpMethod: 'GET',
     });
-    if (!layerInfo.supportedQueryFormats?.includes('geoJSON')) throw new Error('This feature service does not support GeoJSON format.');
-    if (!layerInfo.capabilities?.includes('Query')) throw new Error('This feature service does not support query operations.');
-    if (!layerInfo.advancedQueryCapabilities?.supportsPagination) throw new Error('This feature service does not support query pagination.');
+    if (!layerInfo.supportedQueryFormats.includes('geoJSON')) throw new Error('This feature service does not support GeoJSON format.');
+    if (!layerInfo.capabilities.includes('Query')) throw new Error('This feature service does not support query operations.');
+    if (!layerInfo.advancedQueryCapabilities.supportsPagination) throw new Error('This feature service does not support query pagination.');
     if (!layerInfo.supportsExceedsLimitStatistics) throw new Error('Feature layers hosted in old versions of ArcGIS Enterprise are not supported by this plugin. https://github.com/Esri/maplibre-arcgis/issues/5');
     if (!layerInfo.geometryType || !Object.keys(esriGeometryInfo).includes(layerInfo.geometryType)) throw new Error('This feature service contains an unsupported geometry type.');
 
@@ -225,22 +222,22 @@ export class FeatureLayer extends HostedLayer {
     if (sourceId in this._sources) {
       sourceId += `/${layerInfo.id}`;
     }
+    this._sources[sourceId] = {
+      type: 'geojson',
+      attribution: this._setupAttribution(layerInfo),
+      data: getBlankFc(),
+    };
 
     const options: FeatureLayerSourceManagerOptions = {
       queryOptions: this.query ?? undefined,
       authentication: this._authentication,
       loadingMode: this.loadingMode,
       map: this._map ?? undefined,
+      callback: (features) => { this._updateData(sourceId, features); },
     };
 
     // Create source manager to handle data loading
     this._featureLayerSourceManagers[sourceId] = new FeatureLayerSourceManager(sourceId, layerUrl, layerInfo, options);
-
-    this._sources[sourceId] = {
-      type: 'geojson',
-      attribution: this._setupAttribution(layerInfo),
-      data: () => this._featureLayerSourceManagers[sourceId].data,
-    };
 
     // Initial snapshot mode load
     if (this.loadingMode === 'default' || this.loadingMode === 'snapshot') {
@@ -336,6 +333,10 @@ export class FeatureLayer extends HostedLayer {
 
     this._ready = true;
     return this;
+  }
+
+  private _updateData(sourceId: string, features: FeatureCollection) {
+    this._sources[sourceId].data = features;
   }
 
   protected _onAdd(map: Map) {

--- a/src/FeatureLayer.ts
+++ b/src/FeatureLayer.ts
@@ -210,7 +210,7 @@ export class FeatureLayer extends HostedLayer {
     // const sourceData = await this._fetchFeatures(layerUrl, esriGeometryInfo[layerInfo.geometryType].limit);
 
     // Create maplibre source and layer for the feature layer
-    let sourceId = layerInfo.name;
+    let sourceId = layerInfo.name ?? 'feature-service';
     if (sourceId in this._sources) {
       sourceId += `/${layerInfo.id}`;
     }

--- a/src/FeatureLayer.ts
+++ b/src/FeatureLayer.ts
@@ -7,6 +7,7 @@ import { HostedLayer } from './HostedLayer';
 import { checkItemId, checkServiceUrlType, cleanUrl, getBlankFc, warn, wrapAccessToken } from './Util';
 import type { Map } from 'maplibre-gl';
 import { FeatureLayerSourceManager, type FeatureLayerSourceManagerOptions, type LoadingModeOptions } from './FeatureLayerSourceManager';
+import { type FeatureCollection } from 'geojson';
 // const geoJSONDefaultStyleMap = {
 //     "Point":"circle",
 //     "MultiPoint":"circle",
@@ -156,11 +157,11 @@ export class FeatureLayer extends HostedLayer {
   constructor(options: IFeatureLayerOptions) {
     super();
 
-    if (!options || !(options.itemId || options.url)) throw new Error('Feature layer requires either an \'itemId\' or \'url\'.');
-
     if (options?.token) this.token = options.token;
 
     if (options?.attribution) this._customAttribution = options.attribution;
+
+    if (options?.map) this._map = options.map;
 
     if (options.itemId && options.url)
       warn('Both an item ID and service URL have been passed. Only the item ID will be used.');
@@ -173,6 +174,9 @@ export class FeatureLayer extends HostedLayer {
       const urlType = checkServiceUrlType(options.url);
       if (urlType && (urlType == 'FeatureLayer' || urlType == 'FeatureService')) this._inputType = urlType;
       else throw new Error('Argument `url` is not a valid feature service URL.');
+    }
+    else {
+      throw new Error('Feature layer requires either an \'itemId\' or \'url\'.');
     }
     if (options?.query) this.query = options.query;
 
@@ -223,6 +227,8 @@ export class FeatureLayer extends HostedLayer {
       queryOptions: this.query ?? undefined,
       authentication: this._authentication,
       loadingMode: this._loadingMode,
+      map: this._map ?? undefined,
+      callback: (features) => { this._updateData(sourceId, features); },
     };
 
     // Create source manager to handle data loading
@@ -230,11 +236,10 @@ export class FeatureLayer extends HostedLayer {
 
     // Initial snapshot mode load
     if (this._loadingMode === 'default' || this._loadingMode === 'snapshot') {
-      void this._featureLayerSourceManagers[sourceId]._snapshotLoad(
-        (features) => {
-          this._sources[sourceId].data = features;
-        }
-      );
+      await this._featureLayerSourceManagers[sourceId]._snapshotLoad();
+    }
+    if (this._loadingMode === 'ondemand') {
+      warn('On-demand loading mode is enabled. This layer requires access to the map, either by passing via the constructor or by using a method like addSourcesTo(map). If you are already doing this, you can ignore this message.');
     }
 
     // Create default style layer for rendering
@@ -329,9 +334,15 @@ export class FeatureLayer extends HostedLayer {
     return this;
   }
 
+  private _updateData(sourceId: string, features: FeatureCollection) {
+    this._sources[sourceId].data = features;
+  }
+
   protected _onAdd(map: Map) {
     super._onAdd(map);
-    Object.values(this._featureLayerSourceManagers).forEach(sourceManager => sourceManager.onAdd(map));
+    Object.values(this._featureLayerSourceManagers).forEach((sourceManager) => {
+      sourceManager.onAdd(map);
+    });
   }
 
   /**

--- a/src/FeatureLayer.ts
+++ b/src/FeatureLayer.ts
@@ -2,7 +2,7 @@ import type { GeometryType, IGeometry, ILayerDefinition, ISpatialReference, Spat
 import { getLayer, getService } from '@esri/arcgis-rest-feature-service';
 import { getItem } from '@esri/arcgis-rest-portal';
 import type { GeoJSONSourceSpecification, LayerSpecification } from 'maplibre-gl';
-import type { IHostedLayerOptions, SupportedSourceSpecification } from './HostedLayer';
+import type { IHostedLayerOptions } from './HostedLayer';
 import { HostedLayer } from './HostedLayer';
 import { checkItemId, checkServiceUrlType, cleanUrl, getBlankFc, warn, wrapAccessToken } from './Util';
 import type { Map } from 'maplibre-gl';
@@ -158,6 +158,7 @@ export class FeatureLayer extends HostedLayer {
   constructor(options: IFeatureLayerOptions) {
     super();
 
+    if (!options) throw new Error('Feature layer requires either an \'itemId\' or \'url\'.');
     if (options?.token) this.token = options.token;
 
     if (options?.attribution) this._customAttribution = options.attribution;
@@ -344,27 +345,6 @@ export class FeatureLayer extends HostedLayer {
     Object.values(this._featureLayerSourceManagers).forEach((sourceManager) => {
       sourceManager.onAdd(map);
     });
-  }
-
-  public get source(): Readonly<GeoJSONSourceSpecification> | undefined {
-    const sourceIds = Object.keys(this._sources);
-    if (sourceIds.length !== 1) return undefined;
-
-    return Object.freeze(structuredClone(this.getSource(sourceIds[0])));
-  }
-
-  public get sources(): Readonly<{ [_: string]: SupportedSourceSpecification }> {
-    const sources = Object.fromEntries(
-      Object.entries(this._sources).map(([sourceId, source]) => [sourceId, this.getSource(sourceId)])
-    );
-    return Object.freeze(structuredClone(sources));
-  }
-
-  getSource(sourceId: string): GeoJSONSourceSpecification {
-    return {
-      ...this._sources[sourceId],
-      data: this._sources[sourceId].data(),
-    };
   }
 
   /**

--- a/src/FeatureLayer.ts
+++ b/src/FeatureLayer.ts
@@ -158,21 +158,20 @@ export class FeatureLayer extends HostedLayer {
   constructor(options: IFeatureLayerOptions) {
     super();
 
-    if (!options) throw new Error('Feature layer requires either an \'itemId\' or \'url\'.');
     if (options?.token) this.token = options.token;
 
     if (options?.attribution) this._customAttribution = options.attribution;
 
     if (options?.map) this._map = options.map;
 
-    if (options.itemId && options.url)
+    if (options?.itemId && options?.url)
       warn('Both an item ID and service URL have been passed. Only the item ID will be used.');
 
-    if (options.itemId) {
+    if (options?.itemId) {
       if (checkItemId(options.itemId) == 'ItemId') this._inputType = 'ItemId';
       else throw new Error('Argument `itemId` is not a valid item ID.');
     }
-    else if (options.url) {
+    else if (options?.url) {
       const urlType = checkServiceUrlType(options.url);
       if (urlType && (urlType == 'FeatureLayer' || urlType == 'FeatureService')) this._inputType = urlType;
       else throw new Error('Argument `url` is not a valid feature service URL.');

--- a/src/FeatureLayer.ts
+++ b/src/FeatureLayer.ts
@@ -204,9 +204,9 @@ export class FeatureLayer extends HostedLayer {
       url: layerUrl,
       httpMethod: 'GET',
     });
-    if (!layerInfo.supportedQueryFormats.includes('geoJSON')) throw new Error('This feature service does not support GeoJSON format.');
-    if (!layerInfo.capabilities.includes('Query')) throw new Error('This feature service does not support query operations.');
-    if (!layerInfo.advancedQueryCapabilities.supportsPagination) throw new Error('This feature service does not support query pagination.');
+    if (!layerInfo.supportedQueryFormats?.includes('geoJSON')) throw new Error('This feature service does not support GeoJSON format.');
+    if (!layerInfo.capabilities?.includes('Query')) throw new Error('This feature service does not support query operations.');
+    if (!layerInfo.advancedQueryCapabilities?.supportsPagination) throw new Error('This feature service does not support query pagination.');
     if (!layerInfo.supportsExceedsLimitStatistics) throw new Error('Feature layers hosted in old versions of ArcGIS Enterprise are not supported by this plugin. https://github.com/Esri/maplibre-arcgis/issues/5');
     if (!layerInfo.geometryType || !Object.keys(esriGeometryInfo).includes(layerInfo.geometryType)) throw new Error('This feature service contains an unsupported geometry type.');
 
@@ -217,22 +217,22 @@ export class FeatureLayer extends HostedLayer {
     if (sourceId in this._sources) {
       sourceId += `/${layerInfo.id}`;
     }
-    this._sources[sourceId] = {
-      type: 'geojson',
-      attribution: this._setupAttribution(layerInfo),
-      data: getBlankFc(),
-    };
 
     const options: FeatureLayerSourceManagerOptions = {
       queryOptions: this.query ?? undefined,
       authentication: this._authentication,
       loadingMode: this.loadingMode,
       map: this._map ?? undefined,
-      callback: (features) => { this._updateData(sourceId, features); },
     };
 
     // Create source manager to handle data loading
     this._featureLayerSourceManagers[sourceId] = new FeatureLayerSourceManager(sourceId, layerUrl, layerInfo, options);
+
+    this._sources[sourceId] = {
+      type: 'geojson',
+      attribution: this._setupAttribution(layerInfo),
+      data: this._featureLayerSourceManagers[sourceId].data,
+    };
 
     // Initial snapshot mode load
     if (this.loadingMode === 'default' || this.loadingMode === 'snapshot') {
@@ -332,10 +332,6 @@ export class FeatureLayer extends HostedLayer {
 
     this._ready = true;
     return this;
-  }
-
-  private _updateData(sourceId: string, features: FeatureCollection) {
-    this._sources[sourceId].data = features;
   }
 
   protected _onAdd(map: Map) {

--- a/src/FeatureLayer.ts
+++ b/src/FeatureLayer.ts
@@ -75,7 +75,7 @@ export interface IFeatureLayerOptions extends IHostedLayerOptions {
   itemId?: string;
   url?: string;
   query?: IQueryOptions;
-  _loadingMode?: LoadingModeOptions;
+  loadingMode?: LoadingModeOptions;
 }
 
 /**
@@ -133,7 +133,7 @@ export class FeatureLayer extends HostedLayer {
   private _inputType: SupportedInputTypes;
 
   query?: IQueryOptions;
-  _loadingMode: LoadingModeOptions;
+  loadingMode: LoadingModeOptions;
 
   /**
    * Creates a new FeatureLayer instance. You must provide either an ArcGIS item ID or a feature service URL. If both are provided, the item ID will be used and the URL ignored. Query parameters are only supported when constructing with a feature layer URL.
@@ -193,7 +193,7 @@ export class FeatureLayer extends HostedLayer {
       };
     };
 
-    this._loadingMode = options._loadingMode ? options._loadingMode : 'default';
+    this.loadingMode = options.loadingMode ? options.loadingMode : 'default';
   }
 
   // Initializes an individual layer of the feature service with a source, source manager, and style layer
@@ -226,7 +226,7 @@ export class FeatureLayer extends HostedLayer {
     const options: FeatureLayerSourceManagerOptions = {
       queryOptions: this.query ?? undefined,
       authentication: this._authentication,
-      loadingMode: this._loadingMode,
+      loadingMode: this.loadingMode,
       map: this._map ?? undefined,
       callback: (features) => { this._updateData(sourceId, features); },
     };
@@ -235,10 +235,10 @@ export class FeatureLayer extends HostedLayer {
     this._featureLayerSourceManagers[sourceId] = new FeatureLayerSourceManager(sourceId, layerUrl, layerInfo, options);
 
     // Initial snapshot mode load
-    if (this._loadingMode === 'default' || this._loadingMode === 'snapshot') {
+    if (this.loadingMode === 'default' || this.loadingMode === 'snapshot') {
       await this._featureLayerSourceManagers[sourceId]._snapshotLoad();
     }
-    if (this._loadingMode === 'ondemand') {
+    if (this.loadingMode === 'ondemand' && !this._map) {
       warn('On-demand loading mode is enabled. This layer requires access to the map, either by passing via the constructor or by using a method like addSourcesTo(map). If you are already doing this, you can ignore this message.');
     }
 

--- a/src/FeatureLayer.ts
+++ b/src/FeatureLayer.ts
@@ -200,7 +200,6 @@ export class FeatureLayer extends HostedLayer {
       url: layerUrl,
       httpMethod: 'GET',
     });
-
     if (!layerInfo.supportedQueryFormats.includes('geoJSON')) throw new Error('This feature service does not support GeoJSON format.');
     if (!layerInfo.capabilities.includes('Query')) throw new Error('This feature service does not support query operations.');
     if (!layerInfo.advancedQueryCapabilities.supportsPagination) throw new Error('This feature service does not support query pagination.');
@@ -228,6 +227,15 @@ export class FeatureLayer extends HostedLayer {
 
     // Create source manager to handle data loading
     this._featureLayerSourceManagers[sourceId] = new FeatureLayerSourceManager(sourceId, layerUrl, layerInfo, options);
+
+    // Initial snapshot mode load
+    if (this._loadingMode === 'default' || this._loadingMode === 'snapshot') {
+      void this._featureLayerSourceManagers[sourceId]._snapshotLoad(
+        (features) => {
+          this._sources[sourceId].data = features;
+        }
+      );
+    }
 
     // Create default style layer for rendering
     const layerType = esriGeometryInfo[layerInfo.geometryType].type;

--- a/src/FeatureLayer.ts
+++ b/src/FeatureLayer.ts
@@ -2,7 +2,7 @@ import type { GeometryType, IGeometry, ILayerDefinition, ISpatialReference, Spat
 import { getLayer, getService } from '@esri/arcgis-rest-feature-service';
 import { getItem } from '@esri/arcgis-rest-portal';
 import type { GeoJSONSourceSpecification, LayerSpecification } from 'maplibre-gl';
-import type { IHostedLayerOptions } from './HostedLayer';
+import type { IHostedLayerOptions, SupportedSourceSpecification } from './HostedLayer';
 import { HostedLayer } from './HostedLayer';
 import { checkItemId, checkServiceUrlType, cleanUrl, getBlankFc, warn, wrapAccessToken } from './Util';
 import type { Map } from 'maplibre-gl';
@@ -125,8 +125,12 @@ export type SupportedInputTypes = 'ItemId' | 'FeatureService' | 'FeatureLayer';
  * parks.addSourcesAndLayersTo(map);
  * ```
  */
+export type InternalSourceSpecification = Omit<GeoJSONSourceSpecification, 'data'> & {
+  data: () => GeoJSON.GeoJSON;
+};
+
 export class FeatureLayer extends HostedLayer {
-  declare protected _sources: { [_: string]: GeoJSONSourceSpecification };
+  declare protected _sources: { [_: string]: InternalSourceSpecification };
   private _featureLayerSourceManagers: { [_: string]: FeatureLayerSourceManager };
 
   declare protected _layers: LayerSpecification[];
@@ -194,6 +198,10 @@ export class FeatureLayer extends HostedLayer {
     };
 
     this.loadingMode = options.loadingMode ? options.loadingMode : 'default';
+
+    this._sources = {};
+    this._featureLayerSourceManagers = {};
+    this._layers = [];
   }
 
   // Initializes an individual layer of the feature service with a source, source manager, and style layer
@@ -231,7 +239,7 @@ export class FeatureLayer extends HostedLayer {
     this._sources[sourceId] = {
       type: 'geojson',
       attribution: this._setupAttribution(layerInfo),
-      data: this._featureLayerSourceManagers[sourceId].data,
+      data: () => this._featureLayerSourceManagers[sourceId].data,
     };
 
     // Initial snapshot mode load
@@ -270,10 +278,6 @@ export class FeatureLayer extends HostedLayer {
   }
 
   async initialize(): Promise<FeatureLayer> {
-    this._sources = {};
-    this._featureLayerSourceManagers = {};
-    this._layers = [];
-
     // Wrap access token for use with REST JS
     this._authentication = await wrapAccessToken(this.token, this._itemInfo?.portalUrl);
 
@@ -339,6 +343,27 @@ export class FeatureLayer extends HostedLayer {
     Object.values(this._featureLayerSourceManagers).forEach((sourceManager) => {
       sourceManager.onAdd(map);
     });
+  }
+
+  public get source(): Readonly<GeoJSONSourceSpecification> | undefined {
+    const sourceIds = Object.keys(this._sources);
+    if (sourceIds.length !== 1) return undefined;
+
+    return Object.freeze(structuredClone(this.getSource(sourceIds[0])));
+  }
+
+  public get sources(): Readonly<{ [_: string]: SupportedSourceSpecification }> {
+    const sources = Object.fromEntries(
+      Object.entries(this._sources).map(([sourceId, source]) => [sourceId, this.getSource(sourceId)])
+    );
+    return Object.freeze(structuredClone(sources));
+  }
+
+  getSource(sourceId: string): GeoJSONSourceSpecification {
+    return {
+      ...this._sources[sourceId],
+      data: this._sources[sourceId].data(),
+    };
   }
 
   /**

--- a/src/FeatureLayerSourceManager.ts
+++ b/src/FeatureLayerSourceManager.ts
@@ -113,6 +113,12 @@ export class FeatureLayerSourceManager {
   // =====================
 
   async _snapshotLoad(): Promise<void> {
+    this._pendingSnapshot = this._attemptSnapshotLoad();
+    await this._pendingSnapshot; // awaiting results here for backwards compatibility
+    return;
+  }
+
+  private async _attemptSnapshotLoad(): Promise<boolean> {
     if (!this.layerDefinition?.geometryType) {
       throw new Error('Layer definition with geometry type undefined.');
     }
@@ -121,40 +127,35 @@ export class FeatureLayerSourceManager {
       url: this.layerUrl,
       authentication: this._options.authentication,
     };
-    this._pendingSnapshot = new Promise((resolve) => {
-      const failMsg = 'Unable to load feature service using snapshot mode. Pass the map in the layer constructor or use a method such as addSourceTo(map) to enable on-demand loading. If you are already doing this, you can ignore this message.';
-      this._checkIfExceedsLimit(requestParams, geometryLimit).then((exceedsLimit) => {
-        if (!exceedsLimit) {
-          // load with snapshot mode
-          this._loadFeatureSnapshot().then((featureCollection) => {
-            this._updateSourceData(featureCollection, this.map);
+    const failMsg = 'Unable to load feature service using snapshot mode. Pass the map in the layer constructor or use a method such as addSourceTo(map) to enable on-demand loading. If you are already doing this, you can ignore this message.';
 
-            resolve(true);
-            return;
-          }).catch((err) => {
-            // total failure
-            warn(`${err}`);
-            resolve(false);
-            return;
-          });
+    try {
+      const exceedsLimit = await this._checkIfExceedsLimit(requestParams, geometryLimit);
+
+      if (exceedsLimit) {
+        // if force snapshot mode, fail
+        if (this._options.loadingMode === 'snapshot') {
+          throw new Error('Unable to load using snapshot mode: geometry limit exceeded.');
         }
-        else {
-          // if force snapshot mode, fail
-          if (this._options.loadingMode === 'snapshot') {
-            throw new Error('Unable to load using snapshot mode: geometry limit exceeded.');
-          }
-          warn(failMsg);
-          resolve(false);
-          return;
-        }
-      }).catch((e) => {
         warn(failMsg);
-        resolve(false);
-        return;
-      });
-    });
-    await this._pendingSnapshot; // awaiting results here for backwards compatibility
-    return;
+        return false;
+      }
+
+      try {
+        const featureCollection = await this._loadFeatureSnapshot();
+        this._updateSourceData(featureCollection, this.map);
+        return true;
+      }
+      catch (err) {
+        // total failure
+        warn(`${err}`);
+        return false;
+      }
+    }
+    catch (err) {
+      warn(failMsg);
+      return false;
+    }
   }
 
   private _triggerOnAdd(event: MapSourceDataEvent, sourceId: string) {
@@ -186,7 +187,7 @@ export class FeatureLayerSourceManager {
     // load snapshot mode if specified and under geometry limits
     if (defaultOrSnapshot) {
       // If snapshot mode succeeded on initialization, don't need anything else
-      const snapshotSucceeded = await Promise.resolve(this._pendingSnapshot);
+      const snapshotSucceeded = await (this._pendingSnapshot ?? false);
       if (snapshotSucceeded) return;
     }
 
@@ -340,6 +341,7 @@ export class FeatureLayerSourceManager {
     fc: FeatureCollection
   ) {
     tileFc.features.forEach((feature) => {
+      if (!feature.id) return;
       if (!featureIdIndex.has(feature.id)) {
         fc.features.push(feature);
         featureIdIndex.set(feature.id, true);
@@ -414,7 +416,6 @@ export class FeatureLayerSourceManager {
       ...params,
       outStatistics: [
         {
-
           onStatisticField: null, // Required by REST JS but not used
           statisticType: 'exceedslimit',
           outStatisticFieldName: 'exceedslimit',

--- a/src/FeatureLayerSourceManager.ts
+++ b/src/FeatureLayerSourceManager.ts
@@ -165,7 +165,7 @@ export class FeatureLayerSourceManager {
       // If snapshot mode succeeded on initialization, don't need anything else
       if (this._snapshotSucceeded) return;
 
-      if (this._snapshotLoading) await ... // TODO
+      // if (this._snapshotLoading) await ... // TODO
       // Do we still need this?
       if (this._snapshotSucceeded !== false) await this._snapshotLoad();
     }

--- a/src/FeatureLayerSourceManager.ts
+++ b/src/FeatureLayerSourceManager.ts
@@ -4,7 +4,7 @@ import { queryFeatures, type ILayerDefinition, type IQueryAllFeaturesOptions, qu
 import { getBlankFc, type RestJSAuthenticationManager, warn } from './Util';
 import { bboxToTile, getChildren, tileToQuadkey, tileToBBOX, type Tile } from '@mapbox/tilebelt';
 import { type IGeometry, type IExtent } from '@esri/arcgis-rest-request';
-import { type BBox } from 'geojson';
+import { type BBox, type FeatureCollection } from 'geojson';
 
 // =====================
 // Types and Interfaces
@@ -57,13 +57,14 @@ export class FeatureLayerSourceManager {
   map: MaplibreMap = undefined as unknown as MaplibreMap;
   maplibreSource: GeoJSONSource = undefined as unknown as GeoJSONSource;
   token?: string;
+  private _snapshotSucceeded: boolean | undefined;
   private _snapshotResultRecordCount: number;
   private _onDemandResultRecordCount: number;
   private _onDemandSettings!: OnDemandSettings;
   private _maxExtent: BBox = [-Infinity, Infinity, -Infinity, Infinity];
   private _tileIndices: Map<number, TileIndexMap> = new Map();
   private _featureIndices: Map<number, FeatureIdIndexMap> = new Map();
-  private _featureCollections: Map<number, GeoJSON.FeatureCollection> = new Map();
+  private _featureCollections: Map<number, FeatureCollection> = new Map();
   private _options: FeatureLayerSourceManagerOptions;
   private _maxRecordCountFactor: number;
 
@@ -106,6 +107,49 @@ export class FeatureLayerSourceManager {
     void this._load();
   }
 
+  async _snapshotLoad(callback?: (data: FeatureCollection) => void): Promise<void> {
+    if (!this.layerDefinition?.geometryType) {
+      throw new Error('Layer definition with geometry type undefined.');
+    }
+    const geometryLimit: GeometryLimits = esriGeometryInfo[this.layerDefinition.geometryType].limit;
+    const requestParams: IQueryAllFeaturesOptions = {
+      url: this.layerUrl,
+      authentication: this._options.authentication,
+    };
+    this._snapshotLoading = true;
+    const exceedsLimit = await this._checkIfExceedsLimit(requestParams, geometryLimit);
+    if (!exceedsLimit) {
+      try {
+        // load with snapshot mode
+        const featureCollection = await this._loadFeatureSnapshot();
+        this._snapshotSucceeded = true;
+        this._snapshotLoading = false;
+        if (this.map) this._updateSourceData(this.map, featureCollection);
+        else if (callback) callback(featureCollection);
+
+        return;
+      }
+      catch (err) {
+        // total failure
+        warn('Unable to load using snapshot mode. Pass the map in the layer constructor or use a Maplibre ArcGIS method such as addSourceTo(map) to enable on-demand loading.');
+        // throw new Error(`Unable to load using snapshot mode: ${err}`);
+        this._snapshotSucceeded = false;
+        this._snapshotLoading = false;
+        return;
+      }
+    }
+    else {
+      // if force snapshot mode, fail
+      if (this._options.loadingMode === 'snapshot') {
+        throw new Error('Unable to load using snapshot mode: geometry limit exceeded.');
+      }
+      this._snapshotSucceeded = false;
+      this._snapshotLoading = false;
+      // else, fall back to on-demand
+      return;
+    }
+  }
+
   /**
    * Loads the layer definition and features, using snapshot or on-demand mode as appropriate.
    */
@@ -114,36 +158,16 @@ export class FeatureLayerSourceManager {
     const defaultOrSnapshot = loadingMode === 'default' || loadingMode === 'snapshot';
     const defaultOrOnDemand = loadingMode === 'default' || loadingMode === 'ondemand';
 
+    if (!this.map) throw new Error('Main loading method requires a map');
+
     // load snapshot mode if specified and under geometry limits
     if (defaultOrSnapshot) {
-      if (!this.layerDefinition?.geometryType) {
-        throw new Error('Layer definition with geometry type undefined.');
-      }
-      const geometryLimit: GeometryLimits = esriGeometryInfo[this.layerDefinition.geometryType].limit;
-      const requestParams: IQueryAllFeaturesOptions = {
-        url: this.layerUrl,
-        authentication: this._options.authentication,
-      };
-      const exceedsLimit = await this._checkIfExceedsLimit(requestParams, geometryLimit);
-      if (!exceedsLimit) {
-        try {
-          // load with snapshot mode
-          const featureCollection = await this._loadFeatureSnapshot();
-          this._updateSourceData(this.map, featureCollection);
-          return;
-        }
-        catch (err) {
-          // total failure
-          throw new Error(`Unable to load using snapshot mode: ${err}`);
-        }
-      }
-      else {
-        // if force snapshot mode, fail
-        if (loadingMode === 'snapshot') {
-          throw new Error('Unable to load using snapshot mode: geometry limit exceeded.');
-        }
-        // else, fall back to on-demand
-      }
+      // If snapshot mode succeeded on initialization, don't need anything else
+      if (this._snapshotSucceeded) return;
+
+      if (this._snapshotLoading) await ... // TODO
+      // Do we still need this?
+      if (this._snapshotSucceeded !== false) await this._snapshotLoad();
     }
 
     // fall back to on demand loading
@@ -171,7 +195,7 @@ export class FeatureLayerSourceManager {
    * @param geometryLimit - The geometry limit for this specific layer type, determined via the layer definition
    * @returns - GeoJSON feature collection containing all features in a layer
    */
-  private async _loadFeatureSnapshot() {
+  private async _loadFeatureSnapshot(): Promise<FeatureCollection> {
     const queryParams: IQueryAllFeaturesOptions = {
       url: this.layerUrl,
       authentication: this._options.authentication,
@@ -181,7 +205,7 @@ export class FeatureLayerSourceManager {
     };
 
     const response = await queryAllFeatures(queryParams);
-    const featureCollection = response as unknown as GeoJSON.FeatureCollection;
+    const featureCollection = response as unknown as FeatureCollection;
     if (!featureCollection) {
       throw new Error('Unable to load data.');
     }
@@ -222,8 +246,8 @@ export class FeatureLayerSourceManager {
     tilesToRequest: Tile[],
     tolerance: number,
     featureIdIndex: FeatureIdIndexMap,
-    fc: GeoJSON.FeatureCollection,
-  ): Promise<GeoJSON.FeatureCollection> {
+    fc: FeatureCollection,
+  ): Promise<FeatureCollection> {
     const tileRequests = tilesToRequest.map(tile => this._getTile(tile, tolerance));
     const featureCollections = await Promise.all(tileRequests);
     featureCollections.forEach((tileFc) => {
@@ -282,9 +306,9 @@ export class FeatureLayerSourceManager {
   }
 
   private _addTileFeaturesToFeatureCollection(
-    tileFc: GeoJSON.FeatureCollection,
+    tileFc: FeatureCollection,
     featureIdIndex: FeatureIdIndexMap,
-    fc: GeoJSON.FeatureCollection
+    fc: FeatureCollection
   ) {
     tileFc.features.forEach((feature) => {
       if (!featureIdIndex.has(feature.id)) {
@@ -329,7 +353,7 @@ export class FeatureLayerSourceManager {
       }),
     };
 
-    const res = await queryAllFeatures(queryParams) as unknown as GeoJSON.FeatureCollection;
+    const res = await queryAllFeatures(queryParams) as unknown as FeatureCollection;
     return res;
   }
 
@@ -377,7 +401,7 @@ export class FeatureLayerSourceManager {
     return exceedsLimitResponse.features[0].attributes.exceedslimit === 1;
   }
 
-  private _updateSourceData(map: MaplibreMap, fc: GeoJSON.FeatureCollection): void {
+  private _updateSourceData(map: MaplibreMap, fc: FeatureCollection): void {
     const source: GeoJSONSource | undefined = map.getSource(this.geojsonSourceId);
     if (source) {
       source.setData(fc);

--- a/src/FeatureLayerSourceManager.ts
+++ b/src/FeatureLayerSourceManager.ts
@@ -159,7 +159,6 @@ export class FeatureLayerSourceManager {
 
   private _triggerOnAdd(event: MapSourceDataEvent, sourceId: string) {
     if (event.sourceId === sourceId) {
-      console.log('Adding this source ID to map via trigger:', event.sourceId);
       this.onAdd(this.map);
     }
   }
@@ -442,7 +441,6 @@ export class FeatureLayerSourceManager {
       this._setDataCallback(fc);
     }
     return;
-    // TODO update internal _source value as well -- move this to map
   }
 
   // =====================

--- a/src/FeatureLayerSourceManager.ts
+++ b/src/FeatureLayerSourceManager.ts
@@ -1,9 +1,9 @@
-import { type MapLibreEvent, type GeoJSONSource, type Map as MaplibreMap, MercatorCoordinate, LngLatBounds, type MapSourceDataEvent } from 'maplibre-gl';
+import { type GeoJSONSource, type Map as MaplibreMap, MercatorCoordinate, LngLatBounds, type MapSourceDataEvent } from 'maplibre-gl';
 import { type GeometryLimits, type IQueryOptions, esriGeometryInfo } from './FeatureLayer';
 import { queryFeatures, type ILayerDefinition, type IQueryAllFeaturesOptions, queryAllFeatures, type IQueryFeaturesResponse } from '@esri/arcgis-rest-feature-service';
 import { getBlankFc, type RestJSAuthenticationManager, warn } from './Util';
 import { bboxToTile, getChildren, tileToQuadkey, tileToBBOX, type Tile } from '@mapbox/tilebelt';
-import { type IGeometry, type IExtent } from '@esri/arcgis-rest-request';
+import { type IExtent } from '@esri/arcgis-rest-request';
 import { type BBox, type FeatureCollection } from 'geojson';
 
 // =====================
@@ -19,24 +19,6 @@ interface OnDemandSettings {
   maxZoom: number;
 }
 
-/** Envelope geometry for bounding box operations. */
-interface IEnvelope extends IGeometry {
-  xmin: number;
-  ymin: number;
-  xmax: number;
-  ymax: number;
-  zmin?: number;
-  zmax?: number;
-  mmin?: number;
-  mmax?: number;
-  idmin?: number;
-  idmax?: number;
-}
-
-interface GeometryProjectionResponse {
-  geometries: IGeometry[];
-}
-
 export type LoadingModeOptions = 'default' | 'snapshot' | 'ondemand';
 
 export interface FeatureLayerSourceManagerOptions {
@@ -45,7 +27,6 @@ export interface FeatureLayerSourceManagerOptions {
   useStaticZoomLevel?: boolean;
   loadingMode?: LoadingModeOptions;
   map?: MaplibreMap;
-  callback?: (data: FeatureCollection) => void;
 }
 
 type FeatureIdIndexMap = Map<string | number, boolean>;
@@ -59,7 +40,7 @@ export class FeatureLayerSourceManager {
   map: MaplibreMap = undefined as unknown as MaplibreMap;
   maplibreSource: GeoJSONSource = undefined as unknown as GeoJSONSource;
   token?: string;
-  private _setDataCallback?: (data: FeatureCollection) => void;
+  data: GeoJSON.GeoJSON;
   private _onAddEvent?: (e: MapSourceDataEvent) => void;
   private _pendingSnapshot?: Promise<boolean>;
   private _onDemandActive?: boolean;
@@ -85,6 +66,8 @@ export class FeatureLayerSourceManager {
     this.layerUrl = layerUrl;
     this.layerDefinition = layerDefinition;
 
+    this.data = getBlankFc();
+
     // @ts-expect-error - supportsMaxRecordCountFactor is not included in ILayerDefinition yet
     this._maxRecordCountFactor = this.layerDefinition.advancedQueryCapabilities?.supportsMaxRecordCountFactor ? 4 : 1;
 
@@ -104,8 +87,6 @@ export class FeatureLayerSourceManager {
       this._onAddEvent = e => this._triggerOnAdd(e, this.geojsonSourceId);
       this.map.on('sourcedataloading', this._onAddEvent);
     }
-
-    if (options?.callback) this._setDataCallback = options.callback;
   }
 
   // =====================
@@ -438,9 +419,7 @@ export class FeatureLayerSourceManager {
         source.setData(fc);
       }
     }
-    if (this._setDataCallback) {
-      this._setDataCallback(fc);
-    }
+    this.data = fc;
     return;
   }
 

--- a/src/FeatureLayerSourceManager.ts
+++ b/src/FeatureLayerSourceManager.ts
@@ -169,7 +169,7 @@ export class FeatureLayerSourceManager {
     // load snapshot mode if specified and under geometry limits
     if (defaultOrSnapshot) {
       // If snapshot mode succeeded on initialization, don't need anything else
-      const snapshotSucceeded = await (this._pendingSnapshot ?? false);
+      const snapshotSucceeded = await (this._pendingSnapshot !== undefined ? this._pendingSnapshot : this._attemptSnapshotLoad());
       if (snapshotSucceeded) return;
     }
 

--- a/src/FeatureLayerSourceManager.ts
+++ b/src/FeatureLayerSourceManager.ts
@@ -1,4 +1,4 @@
-import { type MapLibreEvent, type GeoJSONSource, type Map as MaplibreMap, MercatorCoordinate, LngLatBounds } from 'maplibre-gl';
+import { type MapLibreEvent, type GeoJSONSource, type Map as MaplibreMap, MercatorCoordinate, LngLatBounds, type MapSourceDataEvent } from 'maplibre-gl';
 import { type GeometryLimits, type IQueryOptions, esriGeometryInfo } from './FeatureLayer';
 import { queryFeatures, type ILayerDefinition, type IQueryAllFeaturesOptions, queryAllFeatures, type IQueryFeaturesResponse } from '@esri/arcgis-rest-feature-service';
 import { getBlankFc, type RestJSAuthenticationManager, warn } from './Util';
@@ -40,10 +40,12 @@ interface GeometryProjectionResponse {
 export type LoadingModeOptions = 'default' | 'snapshot' | 'ondemand';
 
 export interface FeatureLayerSourceManagerOptions {
-  queryOptions: IQueryOptions;
+  queryOptions?: IQueryOptions;
   authentication?: RestJSAuthenticationManager;
   useStaticZoomLevel?: boolean;
   loadingMode?: LoadingModeOptions;
+  map?: MaplibreMap;
+  callback?: (data: FeatureCollection) => void;
 }
 
 type FeatureIdIndexMap = Map<string | number, boolean>;
@@ -57,7 +59,10 @@ export class FeatureLayerSourceManager {
   map: MaplibreMap = undefined as unknown as MaplibreMap;
   maplibreSource: GeoJSONSource = undefined as unknown as GeoJSONSource;
   token?: string;
-  private _snapshotSucceeded: boolean | undefined;
+  private _setDataCallback?: (data: FeatureCollection) => void;
+  private _onAddEvent?: (e: MapSourceDataEvent) => void;
+  private _pendingSnapshot?: Promise<boolean>;
+  private _onDemandActive?: boolean;
   private _snapshotResultRecordCount: number;
   private _onDemandResultRecordCount: number;
   private _onDemandSettings!: OnDemandSettings;
@@ -93,21 +98,21 @@ export class FeatureLayerSourceManager {
       useStaticZoomLevel: options.useStaticZoomLevel ?? false,
       loadingMode: options.loadingMode ?? 'default',
     };
+
+    if (options?.map) {
+      this.map = options.map;
+      this._onAddEvent = e => this._triggerOnAdd(e, this.geojsonSourceId);
+      this.map.on('sourcedataloading', this._onAddEvent);
+    }
+
+    if (options?.callback) this._setDataCallback = options.callback;
   }
 
   // =====================
   // Main entry points
   // =====================
 
-  /**
-   * Called by Maplibre when the source is added to the map.
-   */
-  public onAdd(map: MaplibreMap) {
-    this.map = map;
-    void this._load();
-  }
-
-  async _snapshotLoad(callback?: (data: FeatureCollection) => void): Promise<void> {
+  async _snapshotLoad(): Promise<void> {
     if (!this.layerDefinition?.geometryType) {
       throw new Error('Layer definition with geometry type undefined.');
     }
@@ -116,75 +121,79 @@ export class FeatureLayerSourceManager {
       url: this.layerUrl,
       authentication: this._options.authentication,
     };
-    this._snapshotLoading = true;
-    const exceedsLimit = await this._checkIfExceedsLimit(requestParams, geometryLimit);
-    if (!exceedsLimit) {
-      try {
-        // load with snapshot mode
-        const featureCollection = await this._loadFeatureSnapshot();
-        this._snapshotSucceeded = true;
-        this._snapshotLoading = false;
-        if (this.map) this._updateSourceData(this.map, featureCollection);
-        else if (callback) callback(featureCollection);
+    this._pendingSnapshot = new Promise((resolve) => {
+      const failMsg = 'Unable to load feature service using snapshot mode. Pass the map in the layer constructor or use a method such as addSourceTo(map) to enable on-demand loading. If you are already doing this, you can ignore this message.';
+      this._checkIfExceedsLimit(requestParams, geometryLimit).then((exceedsLimit) => {
+        if (!exceedsLimit) {
+          // load with snapshot mode
+          this._loadFeatureSnapshot().then((featureCollection) => {
+            this._updateSourceData(featureCollection, this.map);
 
+            resolve(true);
+            return;
+          }).catch((err) => {
+            // total failure
+            warn(`${err}`);
+            resolve(false);
+            return;
+          });
+        }
+        else {
+          // if force snapshot mode, fail
+          if (this._options.loadingMode === 'snapshot') {
+            throw new Error('Unable to load using snapshot mode: geometry limit exceeded.');
+          }
+          warn(failMsg);
+          resolve(false);
+          return;
+        }
+      }).catch((e) => {
+        warn(failMsg);
+        resolve(false);
         return;
-      }
-      catch (err) {
-        // total failure
-        warn('Unable to load using snapshot mode. Pass the map in the layer constructor or use a Maplibre ArcGIS method such as addSourceTo(map) to enable on-demand loading.');
-        // throw new Error(`Unable to load using snapshot mode: ${err}`);
-        this._snapshotSucceeded = false;
-        this._snapshotLoading = false;
-        return;
-      }
+      });
+    });
+    await this._pendingSnapshot; // awaiting results here for backwards compatibility
+    return;
+  }
+
+  private _triggerOnAdd(event: MapSourceDataEvent, sourceId: string) {
+    if (event.sourceId === sourceId) {
+      console.log('Adding this source ID to map via trigger:', event.sourceId);
+      this.onAdd(this.map);
     }
-    else {
-      // if force snapshot mode, fail
-      if (this._options.loadingMode === 'snapshot') {
-        throw new Error('Unable to load using snapshot mode: geometry limit exceeded.');
-      }
-      this._snapshotSucceeded = false;
-      this._snapshotLoading = false;
-      // else, fall back to on-demand
-      return;
-    }
+  }
+
+  /**
+   * Called by Maplibre when the source is added to the map.
+   */
+  public onAdd(map: MaplibreMap) {
+    this.map = map;
+    void this.load();
+
+    if (this._onAddEvent) this.map.off('sourcedataloading', this._onAddEvent);
   }
 
   /**
    * Loads the layer definition and features, using snapshot or on-demand mode as appropriate.
    */
-  private async _load() {
+  public async load() {
     const loadingMode = this._options.loadingMode;
     const defaultOrSnapshot = loadingMode === 'default' || loadingMode === 'snapshot';
     const defaultOrOnDemand = loadingMode === 'default' || loadingMode === 'ondemand';
 
-    if (!this.map) throw new Error('Main loading method requires a map');
+    if (!this.map) throw new Error('Feature service loading requires a map.');
 
     // load snapshot mode if specified and under geometry limits
     if (defaultOrSnapshot) {
       // If snapshot mode succeeded on initialization, don't need anything else
-      if (this._snapshotSucceeded) return;
-
-      // if (this._snapshotLoading) await ... // TODO
-      // Do we still need this?
-      if (this._snapshotSucceeded !== false) await this._snapshotLoad();
+      const snapshotSucceeded = await Promise.resolve(this._pendingSnapshot);
+      if (snapshotSucceeded) return;
     }
 
     // fall back to on demand loading
     if (defaultOrOnDemand) {
-      this._onDemandSettings = {
-        maxTolerance: 156543, // meters per pixel at zoom level 0
-        staticZoomLevel: 7,
-        minZoom: 0,
-        maxZoom: 23,
-      };
-
-      // Use service bounds
-      this._maxExtent = [-Infinity, Infinity, -Infinity, Infinity];
-      if (this.layerDefinition?.extent) this._setMaxExtentFromLayerExtent(this.layerDefinition.extent);
-      this._bindLoadFeaturesToMoveEndEvent();
-      this._clearTiles();
-      void this._loadFeaturesOnDemand();
+      this._startOnDemand();
       return;
     }
     throw new Error('Fatal error: unable to load features.');
@@ -212,6 +221,27 @@ export class FeatureLayerSourceManager {
     return featureCollection;
   }
 
+  private _startOnDemand() {
+    if (this._onDemandActive) return;
+
+    this._onDemandActive = true; // Don't run on-demand again if loading has already started
+
+    this._onDemandSettings = {
+      maxTolerance: 156543, // meters per pixel at zoom level 0
+      staticZoomLevel: 7,
+      minZoom: 0,
+      maxZoom: 23,
+    };
+
+    // Use service bounds
+    this._maxExtent = [-Infinity, Infinity, -Infinity, Infinity];
+    if (this.layerDefinition?.extent) this._setMaxExtentFromLayerExtent(this.layerDefinition.extent);
+    this._bindLoadFeaturesToMoveEndEvent();
+    this._clearTiles();
+    void this._loadFeaturesOnDemand();
+    return;
+  }
+
   /**
    * Loads features on demand for visible tiles.
    */
@@ -230,13 +260,13 @@ export class FeatureLayerSourceManager {
     this._filterRequestedTiles(tilesToRequestAtZoomLevel, tileIndexAtZoomLevel);
 
     if (tilesToRequestAtZoomLevel.length === 0) {
-      this._updateSourceData(this.map, featureCollectionAtZoomLevel);
+      this._updateSourceData(featureCollectionAtZoomLevel, this.map);
       return;
     }
 
     const tolerance = this._calculateTolerance(zoomLevel);
     await this._loadTiles(tilesToRequestAtZoomLevel, tolerance, featureIdIndexAtZoomLevel, featureCollectionAtZoomLevel);
-    this._updateSourceData(this.map, featureCollectionAtZoomLevel);
+    this._updateSourceData(featureCollectionAtZoomLevel, this.map);
   }
 
   /**
@@ -401,12 +431,18 @@ export class FeatureLayerSourceManager {
     return exceedsLimitResponse.features[0].attributes.exceedslimit === 1;
   }
 
-  private _updateSourceData(map: MaplibreMap, fc: FeatureCollection): void {
-    const source: GeoJSONSource | undefined = map.getSource(this.geojsonSourceId);
-    if (source) {
-      source.setData(fc);
-      return;
+  private _updateSourceData(fc: FeatureCollection, map?: MaplibreMap): void {
+    if (map) {
+      const source: GeoJSONSource | undefined = this.map.getSource(this.geojsonSourceId);
+      if (source) {
+        source.setData(fc);
+      }
     }
+    if (this._setDataCallback) {
+      this._setDataCallback(fc);
+    }
+    return;
+    // TODO update internal _source value as well -- move this to map
   }
 
   // =====================

--- a/src/FeatureLayerSourceManager.ts
+++ b/src/FeatureLayerSourceManager.ts
@@ -27,6 +27,7 @@ export interface FeatureLayerSourceManagerOptions {
   useStaticZoomLevel?: boolean;
   loadingMode?: LoadingModeOptions;
   map?: MaplibreMap;
+  callback?: (data: FeatureCollection) => void;
 }
 
 type FeatureIdIndexMap = Map<string | number, boolean>;
@@ -40,7 +41,7 @@ export class FeatureLayerSourceManager {
   map: MaplibreMap = undefined as unknown as MaplibreMap;
   maplibreSource: GeoJSONSource = undefined as unknown as GeoJSONSource;
   token?: string;
-  data: GeoJSON.GeoJSON;
+  private _setDataCallback?: (data: FeatureCollection) => void;
   private _onAddEvent?: (e: MapSourceDataEvent) => void;
   private _pendingSnapshot?: Promise<boolean>;
   private _onDemandActive?: boolean;
@@ -66,8 +67,6 @@ export class FeatureLayerSourceManager {
     this.layerUrl = layerUrl;
     this.layerDefinition = layerDefinition;
 
-    this.data = getBlankFc();
-
     // @ts-expect-error - supportsMaxRecordCountFactor is not included in ILayerDefinition yet
     this._maxRecordCountFactor = this.layerDefinition.advancedQueryCapabilities?.supportsMaxRecordCountFactor ? 4 : 1;
 
@@ -87,6 +86,8 @@ export class FeatureLayerSourceManager {
       this._onAddEvent = e => this._triggerOnAdd(e, this.geojsonSourceId);
       this.map.on('sourcedataloading', this._onAddEvent);
     }
+
+    if (options?.callback) this._setDataCallback = options.callback;
   }
 
   // =====================
@@ -419,7 +420,9 @@ export class FeatureLayerSourceManager {
         source.setData(fc);
       }
     }
-    this.data = fc;
+    if (this._setDataCallback) {
+      this._setDataCallback(fc);
+    }
     return;
   }
 

--- a/src/FeatureLayerSourceManager.ts
+++ b/src/FeatureLayerSourceManager.ts
@@ -109,33 +109,26 @@ export class FeatureLayerSourceManager {
       url: this.layerUrl,
       authentication: this._options.authentication,
     };
-    const failMsg = 'Unable to load feature service using snapshot mode. Pass the map in the layer constructor or use a method such as addSourceTo(map) to enable on-demand loading. If you are already doing this, you can ignore this message.';
 
     try {
       const exceedsLimit = await this._checkIfExceedsLimit(requestParams, geometryLimit);
 
-      if (exceedsLimit) {
-        // if force snapshot mode, fail
-        if (this._options.loadingMode === 'snapshot') {
-          throw new Error('Unable to load using snapshot mode: geometry limit exceeded.');
-        }
-        warn(failMsg);
-        return false;
-      }
+      if (exceedsLimit) throw new Error('Geometry limit exceeded.');
 
-      try {
-        const featureCollection = await this._loadFeatureSnapshot();
-        this._updateSourceData(featureCollection, this.map);
-        return true;
-      }
-      catch (err) {
-        // total failure
-        warn(`${err}`);
-        return false;
-      }
+      const featureCollection = await this._loadFeatureSnapshot();
+      this._updateSourceData(featureCollection, this.map);
+      return true;
     }
     catch (err) {
-      warn(failMsg);
+      if (!(err instanceof Error)) throw err;
+      // if force snapshot mode, fail
+      const msg = `Unable to load feature service using snapshot mode: ${err.message}`;
+      if (this._options.loadingMode === 'snapshot') {
+        throw new Error(msg);
+      }
+      else if (!this.map) {
+        warn(`${msg}\n To enable on-demand loading, pass the MapLibre map in the constructor or use a method such as layer.addSourceTo(map). If you are already doing this, you can ignore this message.`);
+      }
       return false;
     }
   }

--- a/src/FeatureLayerSourceManager.ts
+++ b/src/FeatureLayerSourceManager.ts
@@ -416,7 +416,6 @@ export class FeatureLayerSourceManager {
     if (this._setDataCallback) {
       this._setDataCallback(fc);
     }
-    return;
   }
 
   // =====================

--- a/src/HostedLayer.ts
+++ b/src/HostedLayer.ts
@@ -373,12 +373,12 @@ export abstract class HostedLayer {
     if (this._layers.length === 0) throw new Error('Cannot add layer: Class has zero layers.');
     if (this._layers.length > 1) throw new Error('Class contains multiple layers: use plural `addLayersTo` method instead.');
 
-    const layer = layerOptions ?? this._layers[0];
+    let layer = this._layers[0];
     if (layerOptions) {
-      if (this._layers[0].source) layer.source = this._layers[0].source;
-      if (this._layers[0]['source-layer']) layer['source-layer'] = this._layers[0]['source-layer'];
-
-      if (!layerOptions.id) layerOptions.id = this._layers[0].id;
+      layer = {
+        ...layer,
+        ...layerOptions,
+      };
     }
 
     map.addLayer(layer);
@@ -402,6 +402,31 @@ export abstract class HostedLayer {
     this._onAdd(map);
     return this;
   }
+
+  // TODO - decide if we want this
+  // /**
+  //  * Removes a source from the maplibre map
+  //  * @param map A maplibre map
+  //  * @param sourceId The source ID to remove. Optional if the service only contains a single source.
+  //  */
+  // removeSourceFrom(map: Map, sourceId?: string);
+  // /**
+  //  * Removes all sources from the maplibre map
+  //  * @param map A maplibre map
+  //  */
+  // removeSourcesFrom(map: Map);
+
+  // /**
+  //  * Removes a layer from the maplibre map
+  //  * @param map A maplibre map
+  //  * @param layerId The layer ID to remove. Optional if the service only contains a single layer.
+  //  */
+  // removeLayerFrom(map: Map, layerId: string);
+  // /**
+  //  * Removes all associated layers from the maplibre map
+  //  * @param map A maplibre map
+  //  */
+  // removeLayersFrom(map: Map);
 
   /**
    * Initializes the layer with data from ArcGIS. Called to instantiate a class.

--- a/src/HostedLayer.ts
+++ b/src/HostedLayer.ts
@@ -34,6 +34,21 @@ import type { RestJSAuthenticationManager } from './Util';
  */
 export type SupportedSourceSpecification = VectorSourceSpecification | GeoJSONSourceSpecification;
 
+type SupportedSourceOptions = Omit<GeoJSONSourceSpecification,
+  'type'
+  | 'data'
+  | 'generateId'> // GeoJSON data is immutable
+  & Omit<VectorSourceSpecification,
+  'type'
+  | 'url'
+  | 'tiles'
+  | 'scheme'
+  | 'encoding'
+  >;
+
+type TransformSourceFunction = (sourceId: string, source: SupportedSourceSpecification) => SupportedSourceSpecification;
+type TransformLayerFunction = (layer: LayerSpecification) => LayerSpecification;
+
 /**
  * Options accepted by all instances of HostedLayer.
  */
@@ -90,7 +105,7 @@ export abstract class HostedLayer {
   /**
    * An ArcGIS access token is required for accessing secure data layers. To get a token, go to the [Security and Authentication Guide](https://developers.arcgis.com/documentation/security-and-authentication/get-started/).
    */
-  token: string;
+  token?: string;
 
   protected _authentication?: RestJSAuthenticationManager;
 
@@ -106,7 +121,7 @@ export abstract class HostedLayer {
   /**
    * Stores custom attribution text for the hosted layer
    */
-  protected _customAttribution: string;
+  protected _customAttribution?: string;
 
   /**
    * Retrieves information about the associated hosted data service in ArcGIS.
@@ -271,26 +286,76 @@ export abstract class HostedLayer {
    * Convenience method that adds all associated Maplibre sources and data layers to a map.
    * @param map - A [MapLibre GL JS map](https://maplibre.org/maplibre-gl-js/docs/API/classes/Map/)
    */
-  addSourcesAndLayersTo(map: Map): HostedLayer {
-    if (!this._ready) throw new Error('Cannot add sources and layers to map: Layer is not loaded.');
+  addSourcesAndLayersTo(map: Map, options?: {
+    transformSources?: TransformSourceFunction;
+    transformLayers?: TransformLayerFunction;
+  }): HostedLayer {
+    if (!this._ready) throw new Error('Cannot add sources and layers to map: Class is not initialized.');
     this._map = map;
 
     Object.keys(this._sources).forEach((sourceId) => {
-      map.addSource(sourceId, this._sources[sourceId]);
+      let source = this._sources[sourceId];
+      if (options?.transformSources) source = options.transformSources(sourceId, source);
+      map.addSource(sourceId, source);
     });
     this._layers.forEach((layer) => {
+      if (options?.transformLayers) layer = options.transformLayers(layer);
       map.addLayer(layer);
     });
     this._onAdd(map);
     return this;
   }
 
-  addSourcesTo(map: Map): HostedLayer {
-    if (!this._ready) throw new Error('Cannot add sources to map: Layer is not loaded.');
-    this._map = map;
+  addSourceTo(map: Map, options?: SupportedSourceOptions): HostedLayer {
+    if (!this._ready) throw new Error('Cannot add source to map: Class is not initialized.');
+
+    const sourceIds = Object.keys(this._sources);
+    if (sourceIds.length === 0) throw new Error('Cannot add 0 sources to map.');
+    if (sourceIds.length > 1) throw new Error('Hosted layer class contains more than one source. Use `addSources` function to add all to map.');
+
+    let source = this._sources[sourceIds[0]];
+
+    if (options) {
+      // validate protected options
+      const protectedProperties = ['type', 'data', 'generateId', 'url', 'tiles', 'scheme', 'encoding'];
+      if (protectedProperties.some(property => Object.prototype.hasOwnProperty.call(source, property))) throw new Error('Cannot set protected property of source.');
+      source = {
+        ...source,
+        ...options,
+      };
+    }
+
+    map.addSource(sourceIds[0], source);
+    this._onAdd(map);
+    return this;
+  }
+
+  addSourcesTo(map: Map, transformSources?: TransformSourceFunction): HostedLayer {
+    if (!this._ready) throw new Error('Cannot add sources to map: Class is not initialized.');
+
     Object.keys(this._sources).forEach((sourceId) => {
-      map.addSource(sourceId, this._sources[sourceId]);
+      let source = this._sources[sourceId];
+      if (transformSources) source = transformSources(sourceId, source);
+      map.addSource(sourceId, source);
     });
+    this._onAdd(map);
+    return this;
+  }
+
+  addLayerTo(map: Map, customLayer?: LayerSpecification): HostedLayer {
+    // TODO
+    if (!this._ready) throw new Error('Cannot add layer to map: Class is not initialized.');
+    if (this._layers.length === 0) throw new Error('Cannot add layer: Class has zero layers.');
+    if (this._layers.length > 1) throw new Error('Class contains multiple layers: use plural `addLayersTo` method instead.');
+
+    const layer = customLayer ?? this._layers[0];
+    if (customLayer) {
+      layer.source = this._layers[0].source;
+      layer['source-layer'] = this._layers[0]['source-layer'];
+    }
+
+    map.addLayer(layer);
+
     this._onAdd(map);
     return this;
   }
@@ -300,10 +365,11 @@ export abstract class HostedLayer {
    * @param map - A maplibre map object
    * @returns
    */
-  addLayersTo(map: Map): HostedLayer {
-    if (!this._ready) throw new Error('Cannot add layers to map: Layer is not loaded.');
-    this._map = map;
+  addLayersTo(map: Map, transformLayers?: TransformLayerFunction): HostedLayer {
+    if (!this._ready) throw new Error('Cannot add layers to map: Class is not initialized.');
+
     this._layers.forEach((layer) => {
+      if (transformLayers) layer = transformLayers(layer);
       map.addLayer(layer);
     });
     this._onAdd(map);

--- a/src/HostedLayer.ts
+++ b/src/HostedLayer.ts
@@ -158,6 +158,13 @@ export abstract class HostedLayer {
   protected _map?: Map;
 
   /**
+   * Sets the maplibre map associated with the hosted layer.
+   */
+  public setMap(map: Map) {
+    this._map = map;
+  }
+
+  /**
    * Retrieves the sources for the hosted layer.
    */
   public get sources(): Readonly<{ [_: string]: SupportedSourceSpecification }> {

--- a/src/HostedLayer.ts
+++ b/src/HostedLayer.ts
@@ -285,6 +285,8 @@ export abstract class HostedLayer {
   /**
    * Convenience method that adds all associated Maplibre sources and data layers to a map.
    * @param map - A [MapLibre GL JS map](https://maplibre.org/maplibre-gl-js/docs/API/classes/Map/)
+   * @param options - Optional transform functions for setting properties of sources and layers.
+   * @returns this
    */
   addSourcesAndLayersTo(map: Map, options?: {
     transformSources?: TransformSourceFunction;
@@ -306,7 +308,13 @@ export abstract class HostedLayer {
     return this;
   }
 
-  addSourceTo(map: Map, options?: SupportedSourceOptions): HostedLayer {
+  /**
+   * Adds the maplibre style source to the map. Used when the hosted layer contains a single data source.
+   * @param map - A [MapLibre GL JS map](https://maplibre.org/maplibre-gl-js/docs/API/classes/Map/)
+   * @param sourceOptions - Properties to pass to the added source
+   * @returns this
+   */
+  addSourceTo(map: Map, sourceOptions?: SupportedSourceOptions): HostedLayer {
     if (!this._ready) throw new Error('Cannot add source to map: Class is not initialized.');
 
     const sourceIds = Object.keys(this._sources);
@@ -315,13 +323,13 @@ export abstract class HostedLayer {
 
     let source = this._sources[sourceIds[0]];
 
-    if (options) {
+    if (sourceOptions) {
       // validate protected options
       const protectedProperties = ['type', 'data', 'generateId', 'url', 'tiles', 'scheme', 'encoding'];
       if (protectedProperties.some(property => Object.prototype.hasOwnProperty.call(source, property))) throw new Error('Cannot set protected property of source.');
       source = {
         ...source,
-        ...options,
+        ...sourceOptions,
       };
     }
 
@@ -330,6 +338,12 @@ export abstract class HostedLayer {
     return this;
   }
 
+  /**
+   * Adds maplibre style sources to the map. Used when the hosted layer contains multiple data sources.
+   * @param map - A [MapLibre GL JS map](https://maplibre.org/maplibre-gl-js/docs/API/classes/Map/)
+   * @param transformSources - Transform function to set properties of one or multiple sources
+   * @returns this
+   */
   addSourcesTo(map: Map, transformSources?: TransformSourceFunction): HostedLayer {
     if (!this._ready) throw new Error('Cannot add sources to map: Class is not initialized.');
 
@@ -342,8 +356,13 @@ export abstract class HostedLayer {
     return this;
   }
 
-  addLayerTo(map: Map, customLayer?: LayerSpecification): HostedLayer {
-    // TODO
+  /**
+   * Adds a maplibre style layer to the map. Used when the hosted layer contains a single style layer.
+   * @param map - A [MapLibre GL JS map](https://maplibre.org/maplibre-gl-js/docs/API/classes/Map/)
+   * @param layerOptions - LayerSpecification object to override the default style
+   * @returns this
+   */
+  addLayerTo(map: Map, layerOptions?: LayerSpecification): HostedLayer {
     if (!this._ready) throw new Error('Cannot add layer to map: Class is not initialized.');
     if (this._layers.length === 0) throw new Error('Cannot add layer: Class has zero layers.');
     if (this._layers.length > 1) throw new Error('Class contains multiple layers: use plural `addLayersTo` method instead.');
@@ -361,7 +380,7 @@ export abstract class HostedLayer {
   }
 
   /**
-   * Add layers to a maplibre map.
+   * Adds maplibre style layers to the map. Used when the hosted layer contains multiple style layers.
    * @param map - A maplibre map object
    * @returns
    */

--- a/src/HostedLayer.ts
+++ b/src/HostedLayer.ts
@@ -160,21 +160,21 @@ export abstract class HostedLayer {
   /**
    * Retrieves the sources for the hosted layer.
    */
-  get sources(): Readonly<{ [_: string]: SupportedSourceSpecification }> {
+  public get sources(): Readonly<{ [_: string]: SupportedSourceSpecification }> {
     return Object.freeze(this._sources);
   }
 
   /**
    * Sets the sources for the hosted layer.
    */
-  set sources(value: { [_: string]: SupportedSourceSpecification }) {
+  public set sources(value: { [_: string]: SupportedSourceSpecification }) {
     throwReadOnlyError('sources');
   }
 
   /**
    * Retrieves the source for the hosted layer.
    */
-  get source(): Readonly<SupportedSourceSpecification> | undefined {
+  public get source(): Readonly<SupportedSourceSpecification> | undefined {
     const sourceIds = Object.keys(this._sources);
     if (sourceIds.length !== 1) return undefined;
 
@@ -184,14 +184,14 @@ export abstract class HostedLayer {
   /**
    * Sets the source for the hosted layer.
    */
-  set source(_) {
+  public set source(_) {
     throwReadOnlyError('source');
   }
 
   /**
    * Retrieves the source ID for the hosted layer.
    */
-  get sourceId(): Readonly<string> | undefined {
+  public get sourceId(): Readonly<string> | undefined {
     const sourceIds = Object.keys(this._sources);
     if (sourceIds.length !== 1) return undefined;
 
@@ -201,34 +201,34 @@ export abstract class HostedLayer {
   /**
    * Sets the source ID for the hosted layer.
    */
-  set sourceId(_) {
+  public set sourceId(_) {
     throwReadOnlyError('sourceId');
   }
 
   /**
    * Retrieves the layers for the hosted layer.
    */
-  get layers(): Readonly<LayerSpecification[]> {
+  public get layers(): Readonly<LayerSpecification[]> {
     return Object.freeze(this._layers);
   }
 
   /**
    * Sets the layers for the hosted layer.
    */
-  set layers(_) {
+  public set layers(_) {
     throwReadOnlyError('layers');
   }
 
   /**
    * Retrieves the layer for the hosted layer.
    */
-  get layer(): Readonly<LayerSpecification> | undefined {
+  public get layer(): Readonly<LayerSpecification> | undefined {
     if (this._layers.length !== 1) return undefined;
 
     return Object.freeze(this._layers[0]);
   }
 
-  set layer(_) {
+  public set layer(_) {
     throwReadOnlyError('layer');
   }
 
@@ -245,7 +245,7 @@ export abstract class HostedLayer {
    * @param oldId - The source ID to be changed.
    * @param newId - The new source ID.
    */
-  setSourceId(oldId: string, newId: string): void {
+  public setSourceId(oldId: string, newId: string): void {
     // Update ID of source
     const newSources = structuredClone(this._sources);
     newSources[newId] = newSources[oldId];
@@ -264,7 +264,7 @@ export abstract class HostedLayer {
    * @param sourceId - The ID of the maplibre style source.
    * @param attribution - Custom attribution text.
    */
-  setAttribution(sourceId: string, attribution: string): void {
+  public setAttribution(sourceId: string, attribution: string): void {
     if (!sourceId || !attribution) throw new Error('Must provide a source ID and attribution');
     const newSources = structuredClone(this._sources);
     newSources[sourceId].attribution = attribution;
@@ -275,7 +275,7 @@ export abstract class HostedLayer {
    * Returns a mutable copy of the specified source.
    * @param sourceId - The ID of the maplibre style source to copy.
    */
-  copySource(sourceId: string): SupportedSourceSpecification {
+  public copySource(sourceId: string): SupportedSourceSpecification {
     return structuredClone(this._sources[sourceId]);
   }
 
@@ -283,7 +283,7 @@ export abstract class HostedLayer {
    * Returns a mutable copy of the specified layer
    * @param layerId - The ID of the maplibre style layer to copy
    */
-  copyLayer(layerId: string): LayerSpecification {
+  public copyLayer(layerId: string): LayerSpecification {
     for (let i = 0; i < this._layers.length; i++) {
       if (this._layers[i].id == layerId) return structuredClone(this._layers[i]);
     }
@@ -296,7 +296,7 @@ export abstract class HostedLayer {
    * @param options - Optional transform functions for setting properties of sources and layers.
    * @returns this
    */
-  addSourcesAndLayersTo(map: Map, options?: {
+  public addSourcesAndLayersTo(map: Map, options?: {
     transformSources?: TransformSourceFunction;
     transformLayers?: TransformLayerFunction;
   }): HostedLayer {
@@ -322,7 +322,7 @@ export abstract class HostedLayer {
    * @param sourceOptions - Properties to pass to the added source
    * @returns this
    */
-  addSourceTo(map: Map, sourceOptions?: SupportedSourceOptions): HostedLayer {
+  public addSourceTo(map: Map, sourceOptions?: SupportedSourceOptions): HostedLayer {
     if (!this._ready) throw new Error('Cannot add source to map: Class is not initialized.');
 
     const sourceIds = Object.keys(this._sources);
@@ -352,7 +352,7 @@ export abstract class HostedLayer {
    * @param transformSources - Transform function to set properties of one or multiple sources
    * @returns this
    */
-  addSourcesTo(map: Map, transformSources?: TransformSourceFunction): HostedLayer {
+  public addSourcesTo(map: Map, transformSources?: TransformSourceFunction): HostedLayer {
     if (!this._ready) throw new Error('Cannot add sources to map: Class is not initialized.');
 
     Object.keys(this._sources).forEach((sourceId) => {
@@ -370,7 +370,7 @@ export abstract class HostedLayer {
    * @param layerOptions - LayerSpecification object to override the default style
    * @returns this
    */
-  addLayerTo(map: Map, layerOptions?: SupportedLayerOptions): HostedLayer {
+  public addLayerTo(map: Map, layerOptions?: SupportedLayerOptions): HostedLayer {
     if (!this._ready) throw new Error('Cannot add layer to map: Class is not initialized.');
     if (this._layers.length === 0) throw new Error('Cannot add layer: Class has zero layers.');
     if (this._layers.length > 1) throw new Error('Class contains multiple layers: use plural `addLayersTo` method instead.');
@@ -394,7 +394,7 @@ export abstract class HostedLayer {
    * @param map - A maplibre map object
    * @returns
    */
-  addLayersTo(map: Map, transformLayers?: TransformLayerFunction): HostedLayer {
+  public addLayersTo(map: Map, transformLayers?: TransformLayerFunction): HostedLayer {
     if (!this._ready) throw new Error('Cannot add layers to map: Class is not initialized.');
 
     this._layers.forEach((layer) => {

--- a/src/HostedLayer.ts
+++ b/src/HostedLayer.ts
@@ -53,7 +53,7 @@ type SupportedLayerOptions = Omit<LayerSpecification,
   | 'source-layer'
 >;
 
-type TransformLayerFunction = (layer: LayerSpecification) => LayerSpecification;
+type TransformLayerFunction = (layer: LayerSpecification) => SupportedLayerOptions;
 
 /**
  * Options accepted by all instances of HostedLayer.
@@ -168,7 +168,7 @@ export abstract class HostedLayer {
    * Retrieves the sources for the hosted layer.
    */
   public get sources(): Readonly<{ [_: string]: SupportedSourceSpecification }> {
-    return Object.freeze(this._sources);
+    return Object.freeze(structuredClone(this._sources));
   }
 
   /**
@@ -185,7 +185,7 @@ export abstract class HostedLayer {
     const sourceIds = Object.keys(this._sources);
     if (sourceIds.length !== 1) return undefined;
 
-    return Object.freeze(this._sources[sourceIds[0]]);
+    return Object.freeze(structuredClone(this._sources[sourceIds[0]]));
   }
 
   /**
@@ -202,7 +202,7 @@ export abstract class HostedLayer {
     const sourceIds = Object.keys(this._sources);
     if (sourceIds.length !== 1) return undefined;
 
-    return Object.freeze(sourceIds[0]);
+    return Object.freeze(structuredClone(sourceIds[0]));
   }
 
   /**
@@ -216,7 +216,7 @@ export abstract class HostedLayer {
    * Retrieves the layers for the hosted layer.
    */
   public get layers(): Readonly<LayerSpecification[]> {
-    return Object.freeze(this._layers);
+    return Object.freeze(structuredClone(this._layers));
   }
 
   /**
@@ -232,7 +232,7 @@ export abstract class HostedLayer {
   public get layer(): Readonly<LayerSpecification> | undefined {
     if (this._layers.length !== 1) return undefined;
 
-    return Object.freeze(this._layers[0]);
+    return Object.freeze(structuredClone(this._layers[0]));
   }
 
   public set layer(_) {
@@ -411,31 +411,6 @@ export abstract class HostedLayer {
     this._onAdd(map);
     return this;
   }
-
-  // TODO - decide if we want this
-  // /**
-  //  * Removes a source from the maplibre map
-  //  * @param map A maplibre map
-  //  * @param sourceId The source ID to remove. Optional if the service only contains a single source.
-  //  */
-  // removeSourceFrom(map: Map, sourceId?: string);
-  // /**
-  //  * Removes all sources from the maplibre map
-  //  * @param map A maplibre map
-  //  */
-  // removeSourcesFrom(map: Map);
-
-  // /**
-  //  * Removes a layer from the maplibre map
-  //  * @param map A maplibre map
-  //  * @param layerId The layer ID to remove. Optional if the service only contains a single layer.
-  //  */
-  // removeLayerFrom(map: Map, layerId: string);
-  // /**
-  //  * Removes all associated layers from the maplibre map
-  //  * @param map A maplibre map
-  //  */
-  // removeLayersFrom(map: Map);
 
   /**
    * Initializes the layer with data from ArcGIS. Called to instantiate a class.

--- a/src/HostedLayer.ts
+++ b/src/HostedLayer.ts
@@ -47,6 +47,12 @@ type SupportedSourceOptions = Omit<GeoJSONSourceSpecification,
   >;
 
 type TransformSourceFunction = (sourceId: string, source: SupportedSourceSpecification) => SupportedSourceSpecification;
+
+type SupportedLayerOptions = Omit<LayerSpecification,
+  'source'
+  | 'source-layer'
+>;
+
 type TransformLayerFunction = (layer: LayerSpecification) => LayerSpecification;
 
 /**
@@ -326,7 +332,7 @@ export abstract class HostedLayer {
     if (sourceOptions) {
       // validate protected options
       const protectedProperties = ['type', 'data', 'generateId', 'url', 'tiles', 'scheme', 'encoding'];
-      if (protectedProperties.some(property => Object.prototype.hasOwnProperty.call(source, property))) throw new Error('Cannot set protected property of source.');
+      if (protectedProperties.some(property => Object.prototype.hasOwnProperty.call(sourceOptions, property))) throw new Error('Cannot set protected property of source.');
       source = {
         ...source,
         ...sourceOptions,
@@ -362,15 +368,17 @@ export abstract class HostedLayer {
    * @param layerOptions - LayerSpecification object to override the default style
    * @returns this
    */
-  addLayerTo(map: Map, layerOptions?: LayerSpecification): HostedLayer {
+  addLayerTo(map: Map, layerOptions?: SupportedLayerOptions): HostedLayer {
     if (!this._ready) throw new Error('Cannot add layer to map: Class is not initialized.');
     if (this._layers.length === 0) throw new Error('Cannot add layer: Class has zero layers.');
     if (this._layers.length > 1) throw new Error('Class contains multiple layers: use plural `addLayersTo` method instead.');
 
-    const layer = customLayer ?? this._layers[0];
-    if (customLayer) {
-      layer.source = this._layers[0].source;
-      layer['source-layer'] = this._layers[0]['source-layer'];
+    const layer = layerOptions ?? this._layers[0];
+    if (layerOptions) {
+      if (this._layers[0].source) layer.source = this._layers[0].source;
+      if (this._layers[0]['source-layer']) layer['source-layer'] = this._layers[0]['source-layer'];
+
+      if (!layerOptions.id) layerOptions.id = this._layers[0].id;
     }
 
     map.addLayer(layer);

--- a/src/HostedLayer.ts
+++ b/src/HostedLayer.ts
@@ -68,6 +68,8 @@ export interface IHostedLayerOptions {
    */
   portalUrl?: string;
   attribution?: string;
+
+  map?: Map;
 }
 
 /**

--- a/src/Util.ts
+++ b/src/Util.ts
@@ -23,6 +23,7 @@ export const checkServiceUrlType = (serviceUrl: string): SupportedServiceType | 
       return 'VectorTileService';
     };
 
+    const mapServiceTest = //.
     const featureServiceTest = /\/FeatureServer\/?([0-9]*\/?)?$/.exec(serviceUrl);
     if (featureServiceTest) {
       if (featureServiceTest.length == 2 && featureServiceTest[1]) {
@@ -110,8 +111,8 @@ export const checkAccessTokenType = (token: string): 'user' | 'app' | 'basemapSe
   // Token type not recognized; default to 'app'
   return 'app';
 };
-export const wrapAccessToken = async (token: string, portalUrl?: string): Promise<ApiKeyManager | ArcGISIdentityManager> => {
-  if (!token || token.length === 0) return null;
+export const wrapAccessToken = async (token?: string, portalUrl?: string): Promise<ApiKeyManager | ArcGISIdentityManager | undefined> => {
+  if (!token || token.length === 0) return undefined;
   const tokenType = checkAccessTokenType(token);
   // User tokens
   if (tokenType === 'user') return await ArcGISIdentityManager.fromToken({

--- a/src/Util.ts
+++ b/src/Util.ts
@@ -23,7 +23,6 @@ export const checkServiceUrlType = (serviceUrl: string): SupportedServiceType | 
       return 'VectorTileService';
     };
 
-    const mapServiceTest = //.
     const featureServiceTest = /\/FeatureServer\/?([0-9]*\/?)?$/.exec(serviceUrl);
     if (featureServiceTest) {
       if (featureServiceTest.length == 2 && featureServiceTest[1]) {

--- a/test/FeatureLayer.test.ts
+++ b/test/FeatureLayer.test.ts
@@ -24,6 +24,26 @@ export const test = customTest.extend({
     await trailsLayer.initialize();
 
     await use(trailsLayer);
+  },
+
+  maplibreLayerOptions: async ({}, use) => {
+    const layerOptions = {
+      type: 'line',
+      paint: {
+        'line-color': '#ff00ff',
+        'line-width': 5
+      }
+    };
+    await use(layerOptions)
+  },
+
+  maplibreSourceOptions: async ({}, use) => {
+    const sourceOptions = {
+      cluster: true,
+      clusterRadius:100,
+      clusterMaxZoom: 10,
+    };
+    await use(sourceOptions);
   }
 })
 
@@ -592,7 +612,7 @@ describe('Feature layer unit tests', () => {
     expect(layer2.sourceId).toEqual(trailsMock.layerDefinitionRaw.name);
   });
 
-  describe('Methods inherited from HostedLayer work properly.', () => {
+  describe.skip('Methods inherited from HostedLayer work properly.', () => {
     test('`layer`, `layers, `source`, `sources`, `sourceId` are read-only properties containing style data.', ({trailsLayer}) => {
       expect(trailsLayer.layer).toBe(trailsLayer._layers[0]);
       expect(trailsLayer.layers).toBe(trailsLayer._layers);
@@ -628,8 +648,8 @@ describe('Feature layer unit tests', () => {
   });
 });
 
-describe.skip('Works on a mock page with a `Map`',() => {
-  test('Uninitialized layers created using the constructor cannot be added to the map.', async ({setupPage})=>{
+describe('Works on a mock page with a `Map`',() => {
+  test('Uninitialized layers cannot be added to the map.', async ({setupPage})=>{
     const page = await setupPage('feature-layer.html');
 
     await page.waitForFunction(()=> window.map && window.featureLayer);
@@ -638,44 +658,83 @@ describe.skip('Works on a mock page with a `Map`',() => {
       await page.evaluate(() => {
         window.featureLayer.addSourcesAndLayersTo(window.map);
       })
-    }).rejects.toThrowError('Cannot add sources and layers to map: Layer is not loaded.');
+    }).rejects.toThrowError('Cannot add sources and layers to map: Class is not initialized.');
 
     await expect(async () => {
       await page.evaluate(() => {
         window.featureLayer.addSourcesTo(window.map);
       })
-    }).rejects.toThrowError('Cannot add sources to map: Layer is not loaded.');
+    }).rejects.toThrowError('Cannot add sources to map: Class is not initialized.');
 
-        await expect(async () => {
+    await expect(async () => {
       await page.evaluate(() => {
         window.featureLayer.addLayersTo(window.map);
       })
-    }).rejects.toThrowError('Cannot add layers to map: Layer is not loaded.');
+    }).rejects.toThrowError('Cannot add layers to map: Class is not initialized.');
+
+    await expect(async () => {
+      await page.evaluate(() => {
+        window.featureLayer.addLayerTo(window.map);
+      })
+    }).rejects.toThrowError('Cannot add layer to map: Class is not initialized.');
+
+    await expect(async () => {
+      await page.evaluate(() => {
+        window.featureLayer.addSourceTo(window.map);
+      })
+    }).rejects.toThrowError('Cannot add source to map: Class is not initialized.');
   });
 
-  test('`addSourcesTo` and `addLayersTo` add source and layers to the maplibre map.', async ({setupPage}) => {
+  test('`addSourceTo` adds a GeoJSON source to map, `addLayerTo` adds a layer to map, and both throw if multiple layers are present.', async ({setupPage}) => {
     const page = await setupPage('feature-layer.html');
     await page.waitForFunction(()=>window.map && window.featureLayer);
 
-    const {style} = await page.evaluate(async () => {
+    const {mapStyle} = await page.evaluate(async () => {
+      await window.featureLayer.initialize(); // This layer uses forced on-demand loading
+
+      window.featureLayer.addSourceTo(window.map);
+      window.featureLayer.addLayerTo(window.map);
+
+      return await new Promise(resolve => {
+        window.map.on('load', ()=> {
+          resolve({
+            mapStyle: window.map.getStyle()
+          })
+        });
+      })
+    });
+
+    expect(Object.keys(mapStyle.sources).length).toBe(1);
+    expect(mapStyle.sources[Object.keys(mapStyle.sources)[0]].data).toEqual(getBlankFc()); // Blank FC since data is loaded dynamically
+
+    expect(mapStyle.layers.length).toBe(1);
+    expect(mapStyle.layers[0].source).toBe(Object.keys(mapStyle.sources)[0]);
+  });
+
+  test('`addSourcesTo` and `addLayersTo` add sources and layers to the maplibre map.', async ({setupPage}) => {
+    const page = await setupPage('feature-layer.html');
+    await page.waitForFunction(()=>window.map && window.featureLayer);
+
+    const {mapStyle} = await page.evaluate(async () => {
       await window.featureLayer.initialize();
       window.featureLayer.addSourcesTo(window.map);
       window.featureLayer.addLayersTo(window.map);
 
       return await new Promise(resolve => {
-        window.map.on("load", ()=> {
+        window.map.on('load', ()=> {
           resolve({
-            style: window.map.getStyle()
+            mapStyle: window.map.getStyle()
           })
         });
       });
     });
-    expect(Object.keys(style.sources).length).toBe(1);
-    expect(style.sources[Object.keys(style.sources)[0]].data).toEqual(getBlankFc());
+    expect(Object.keys(mapStyle.sources).length).toBe(1);
+    expect(mapStyle.sources[Object.keys(mapStyle.sources)[0]].data).toEqual(getBlankFc());
 
-    expect(style.layers.length).toBe(1);
-    expect(style.layers[0].source).toBe(Object.keys(style.sources)[0]);
+    expect(mapStyle.layers.length).toBe(1);
+    expect(mapStyle.layers[0].source).toBe(Object.keys(mapStyle.sources)[0]);
   });
+
   test('`addSourcesAndLayersTo` adds sources and layers to the maplibre map.', async ({setupPage}) => {
     const page = await setupPage('feature-layer.html');
     await page.waitForFunction(()=>window.map && window.featureLayer);
@@ -698,7 +757,108 @@ describe.skip('Works on a mock page with a `Map`',() => {
     expect(style.layers.length).toBe(1);
     expect(style.layers[0].source).toBe(Object.keys(style.sources)[0]);
   });
-  test('Works with native maplibre `addSource` and `addLayer` methods.', async ({setupPage}) => {
+
+  test('`addSourceTo` and `addLayerTo` accept maplibre options and pass them to the maplibre map.', async ({setupPage, maplibreSourceOptions, maplibreLayerOptions}) => {
+
+    const page = await setupPage('feature-layer.html');
+    await page.waitForFunction(()=>window.map && window.featureLayer);
+
+
+    const {mapStyle} = await page.evaluate(async (params) => {
+      await window.featureLayer.initialize();
+
+      window.featureLayer.addSourceTo(window.map, params.maplibreSourceOptions);
+      window.featureLayer.addLayerTo(window.map, params.maplibreLayerOptions);
+
+      return await new Promise(resolve => {
+        window.map.on('load', ()=> {
+          resolve({
+            mapStyle: window.map.getStyle()
+          })
+        });
+      })
+    }, {maplibreSourceOptions, maplibreLayerOptions});
+
+    expect(Object.values(mapStyle.sources)[0]).toEqual(expect.objectContaining(maplibreSourceOptions));
+
+    expect(mapStyle.layers[0]).toEqual(expect.objectContaining(maplibreLayerOptions));
+  });
+
+  test('`addSourcesTo` and `addLayersTo` accept transform functions for setting maplibre options.', async ({setupPage, maplibreSourceOptions, maplibreLayerOptions}) => {
+
+    const page = await setupPage('feature-layer.html');
+    await page.waitForFunction(()=>window.map && window.featureLayer);
+
+    const {mapStyle} = await page.evaluate(async (params) => {
+      await window.featureLayer.initialize();
+
+      window.featureLayer.addSourcesTo(window.map, (sourceId, source) => {
+        return {
+          ...source,
+          ...params.maplibreSourceOptions
+        }
+      });
+      window.featureLayer.addLayersTo(window.map, (layer) => {
+        return {
+          ...layer,
+          ...params.maplibreLayerOptions
+        }
+      });
+
+      return await new Promise(resolve => {
+        window.map.on('load', ()=> {
+          resolve({
+            mapStyle: window.map.getStyle()
+          })
+        });
+      })
+    }, {maplibreSourceOptions, maplibreLayerOptions});
+
+    expect(Object.values(mapStyle.sources)[0]).toEqual(expect.objectContaining(maplibreSourceOptions));
+    expect(mapStyle.layers[0]).toEqual(expect.objectContaining(maplibreLayerOptions));
+
+  });
+
+  test('`addSourcesAndLayersTo` accepts transform functions for setting maplibre options.', async ({setupPage, maplibreSourceOptions, maplibreLayerOptions}) => {
+
+    const page = await setupPage('feature-layer.html');
+    await page.waitForFunction(()=>window.map && window.featureLayer);
+
+    const {mapStyle} = await page.evaluate(async (params) => {
+      await window.featureLayer.initialize();
+
+
+      window.featureLayer.addSourcesAndLayersTo(window.map, {
+        transformSources: (sourceId, source) => {
+          return {
+            ...source,
+            ...params.maplibreSourceOptions
+          }
+        },
+        transformLayers: (layer) => {
+          return {
+            ...layer,
+            ...params.maplibreLayerOptions
+          }
+        }
+      });
+
+      return await new Promise(resolve => {
+        window.map.on('load', ()=> {
+          resolve({
+            mapStyle: window.map.getStyle()
+          })
+        });
+      })
+    }, {maplibreSourceOptions, maplibreLayerOptions});
+
+    expect(Object.values(mapStyle.sources)[0]).toEqual(expect.objectContaining(maplibreSourceOptions));
+    expect(mapStyle.layers[0]).toEqual(expect.objectContaining(maplibreLayerOptions));
+
+  });
+
+  // TODO
+  test.skip('Works with native maplibre `addSource` and `addLayer` methods.', async ({setupPage}) => {
     const page = await setupPage('feature-layer.html');
     await page.waitForFunction(() => window.map && window.featureLayer);
 

--- a/test/FeatureLayer.test.ts
+++ b/test/FeatureLayer.test.ts
@@ -119,9 +119,19 @@ describe('Feature layer unit tests', () => {
     });
   });
 
-  // TODO
-  test('Accepts a loadingMode parameter that sets the loading mode to snapshot or on-demand,', async () => {});
-  test('Warns the user if on-demand loading mode is set without a map provided.', async () => {});
+  test('Warns the user if on-demand loading mode is set without a map provided.', async () => {
+
+    const warnSpy = vi.spyOn(console,'warn')
+    const featureLayer = new FeatureLayer({
+      url: trailsMock.layerUrl,
+      loadingMode: 'ondemand'
+    });
+
+    fetchMock.once(trailsMock.layerDefinition)
+    await featureLayer.initialize();
+
+    expect(warnSpy).toHaveBeenCalledWith('On-demand loading mode is enabled. This layer requires access to the map, either by passing via the constructor or by using a method like addSourcesTo(map). If you are already doing this, you can ignore this message.');
+  });
 
   describe('Supports a `query` parameter.', () => {
     test('Accepts a `query` parameter.', async () => {

--- a/test/FeatureLayer.test.ts
+++ b/test/FeatureLayer.test.ts
@@ -18,9 +18,10 @@ export const test = customTest.extend({
   /* Trails dataset */
   trailsLayer: async ({}, use)=> {
     const trailsLayer = new FeatureLayer({
-      url: trailsMock.layerUrl
+      url: trailsMock.layerUrl,
+      loadingMode: 'snapshot'
     });
-    fetchMock.once(trailsMock.layerDefinition);
+    fetchMock.once(trailsMock.layerDefinition).once(trailsMock.exceedsLimitResponse).once(trailsMock.geoJSONSmall);
     await trailsLayer.initialize();
 
     await use(trailsLayer);
@@ -117,6 +118,10 @@ describe('Feature layer unit tests', () => {
       expect(getLayer).toHaveBeenCalledWith(expect.objectContaining({authentication: apiKeyManager}));
     });
   });
+
+  // TODO
+  test('Accepts a loadingMode parameter that sets the loading mode to snapshot or on-demand,', async () => {});
+  test('Warns the user if on-demand loading mode is set without a map provided.', async () => {});
 
   describe('Supports a `query` parameter.', () => {
     test('Accepts a `query` parameter.', async () => {
@@ -229,7 +234,8 @@ describe('Feature layer unit tests', () => {
       const { getService } = await import('@esri/arcgis-rest-feature-service');
 
       const featureService = new FeatureLayer({
-        url: trailsMock.serviceUrl
+        url: trailsMock.serviceUrl,
+        loadingMode: 'ondemand'
       });
       fetchMock.once(trailsMock.serviceDefinition).once(trailsMock.layerDefinition);
       await featureService.initialize();
@@ -240,7 +246,8 @@ describe('Feature layer unit tests', () => {
       const { getLayer } = await import('@esri/arcgis-rest-feature-service');
 
       const layer = new FeatureLayer({
-        url: trailsMock.layerUrl
+        url: trailsMock.layerUrl,
+        loadingMode: 'ondemand'
       });
       fetchMock.once(trailsMock.layerDefinition);
       await layer.initialize();
@@ -248,7 +255,8 @@ describe('Feature layer unit tests', () => {
     });
     test('If the service contains multiple layers, load up to 10 and log a warning if there are too many.', async () => {
       const featureService = new FeatureLayer({
-        url: multiLayerMock.serviceUrl
+        url: multiLayerMock.serviceUrl,
+        loadingMode: 'ondemand'
       });
       const warningSpy = vi.spyOn(console, 'warn').mockImplementation((warningText) => {});
 
@@ -362,9 +370,29 @@ describe('Feature layer unit tests', () => {
       }).rejects.toThrowError('This feature service does not support query pagination.');
     });
 
-    test('Initializes each layer with an empty GeoJSONDataSource.', async () => {
+    test('Initializes snapshot layers with a GeoJSONDataSource containing data.', async () => {
       const layer = new FeatureLayer({
-        url: trailsMock.layerUrl
+        url: trailsMock.layerUrl,
+        loadingMode: 'snapshot'
+      });
+      fetchMock.once(trailsMock.layerDefinition).once(trailsMock.exceedsLimitResponse).once(trailsMock.geoJSONSmall);
+      await layer.initialize();
+
+      expect(Object.keys(layer._sources).length).toBe(1);
+      // Source ID is taken from the layer definition
+      const sourceId = Object.keys(layer._sources)[0];
+      expect(sourceId).toBe(trailsMock.layerDefinitionRaw.name);
+      // Blank FC, type geojson, among other properties
+      expect(layer._sources[sourceId]).toEqual(expect.objectContaining({
+        data: trailsMock.geoJSONSmallRaw,
+        type: 'geojson'
+      }));
+    });
+
+    test('Initializes on-demand layers with an empty GeoJSONDataSource.', async () => {
+      const layer = new FeatureLayer({
+        url: trailsMock.layerUrl,
+        loadingMode: 'ondemand'
       });
       fetchMock.once(trailsMock.layerDefinition);
       await layer.initialize();
@@ -386,7 +414,8 @@ describe('Feature layer unit tests', () => {
         query: {
           where: '1=1'
         },
-        token: 'placeholderApiKey'
+        token: 'placeholderApiKey',
+        loadingMode: 'ondemand'
       });
       fetchMock.once(trailsMock.layerDefinition);
       await layer.initialize();
@@ -400,12 +429,6 @@ describe('Feature layer unit tests', () => {
       expect(sourceManager.layerUrl).toEqual(cleanUrl(trailsMock.layerUrl));
       // Passes the source ID
       expect(sourceManager.geojsonSourceId).toEqual(sourceId);
-    });
-
-    test('The data within each GeoJSONSource is managed by a FeatureLayerSourceManager.', async () => {
-      // TODO
-      // initialize layer, trigger loading, then verify the source data is updating
-      // requires mock map
     });
   });
 
@@ -507,21 +530,24 @@ describe('Feature layer unit tests', () => {
       // Lines
       fetchMock.once(trailsMock.layerDefinition);
       const lines = new FeatureLayer({
-        url: trailsMock.layerUrl
+        url: trailsMock.layerUrl,
+        loadingMode: 'ondemand'
       });
       await lines.initialize();
 
       // Points
       fetchMock.once(pointsMock.layerDefinition);
       const points = new FeatureLayer({
-        url: pointsMock.layerUrl
+        url: pointsMock.layerUrl,
+        loadingMode: 'ondemand'
       });
       await points.initialize();
 
       // Polygons
       fetchMock.once(polygonsMock.layerDefinition);
       const polygons = new FeatureLayer({
-        url: polygonsMock.layerUrl
+        url: polygonsMock.layerUrl,
+        loadingMode: 'ondemand'
       });
       await polygons.initialize();
 
@@ -550,7 +576,7 @@ describe('Feature layer unit tests', () => {
         attribution: 'User-provided attribution.'
       });
 
-      fetchMock.once(trailsMock.item).once(trailsMock.serviceDefinition).once(trailsMock.layerDefinition);
+      fetchMock.once(trailsMock.item).once(trailsMock.serviceDefinition).once(trailsMock.layerDefinition).once(trailsMock.exceedsLimitResponse).once(trailsMock.geoJSONSmall);
       await layer.initialize();
 
       expect(layer._sources['Trails_0'].attribution).toBe('User-provided attribution.')
@@ -560,7 +586,7 @@ describe('Feature layer unit tests', () => {
         itemId: trailsMock.itemId
       });
 
-      fetchMock.once(trailsMock.item).once(trailsMock.serviceDefinition).once(trailsMock.layerDefinition);
+      fetchMock.once(trailsMock.item).once(trailsMock.serviceDefinition).once(trailsMock.layerDefinition).once(trailsMock.exceedsLimitResponse).once(trailsMock.geoJSONSmall);
       await layer.initialize();
 
       expect(layer._sources['Trails_0'].attribution).toBe('Access information from item info.');
@@ -570,7 +596,7 @@ describe('Feature layer unit tests', () => {
         url: trailsMock.serviceUrl
       });
 
-      fetchMock.once(trailsMock.serviceDefinition).once(trailsMock.layerDefinition);
+      fetchMock.once(trailsMock.serviceDefinition).once(trailsMock.layerDefinition).once(trailsMock.exceedsLimitResponse).once(trailsMock.geoJSONSmall);
       await layer.initialize();
       expect(layer._sources['Trails_0'].attribution).toBe('Copyright text from layer info.');
     });
@@ -583,14 +609,14 @@ describe('Feature layer unit tests', () => {
         ...trailsMock.layerDefinitionRaw,
         copyrightText: null
       })
-      fetchMock.once(trailsMock.serviceDefinition).once(emptyCopyrightLayerInfo);
+      fetchMock.once(trailsMock.serviceDefinition).once(emptyCopyrightLayerInfo).once(trailsMock.exceedsLimitResponse).once(trailsMock.geoJSONSmall);
       await layer.initialize();
       expect(layer._sources['Trails_0'].attribution).toBe('Copyright text from service info.');
     });
   });
 
   test('Initializes a layer from item ID with the `fromPortalItem` static method.', async () => {
-    fetchMock.once(trailsMock.item).once(trailsMock.serviceDefinition).once(trailsMock.layerDefinition);
+    fetchMock.once(trailsMock.item).once(trailsMock.serviceDefinition).once(trailsMock.layerDefinition).once(trailsMock.exceedsLimitResponse).once(trailsMock.geoJSONSmall);
     const layer = await FeatureLayer.fromPortalItem(trailsMock.itemId);
     expect(layer.source).toBeDefined();
     expect(layer.layer).toBeDefined();
@@ -598,14 +624,14 @@ describe('Feature layer unit tests', () => {
   });
   test('Creates a layer from service URL with the `fromUrl` static method.', async () => {
     // From service URL
-    fetchMock.once(trailsMock.serviceDefinition).once(trailsMock.layerDefinition);
+    fetchMock.once(trailsMock.serviceDefinition).once(trailsMock.layerDefinition).once(trailsMock.exceedsLimitResponse).once(trailsMock.geoJSONSmall);
     const layer = await FeatureLayer.fromUrl(trailsMock.serviceUrl);
     expect(layer.source).toBeDefined();
     expect(layer.layer).toBeDefined();
     expect(layer.sourceId).toEqual(trailsMock.layerDefinitionRaw.name);
 
     // From layer URL
-    fetchMock.once(trailsMock.layerDefinition);
+    fetchMock.once(trailsMock.layerDefinition).once(trailsMock.exceedsLimitResponse).once(trailsMock.geoJSONSmall);
     const layer2 = await FeatureLayer.fromUrl(trailsMock.layerUrl);
     expect(layer2.source).toBeDefined();
     expect(layer2.layer).toBeDefined();
@@ -614,12 +640,12 @@ describe('Feature layer unit tests', () => {
 
   describe('Methods inherited from HostedLayer work properly.', () => {
     test('`layer`, `layers, `source`, `sources`, `sourceId` are read-only properties containing style data.', ({trailsLayer}) => {
-      expect(trailsLayer.layer).toBe(trailsLayer._layers[0]);
-      expect(trailsLayer.layers).toBe(trailsLayer._layers);
+      expect(trailsLayer.layer).toEqual(trailsLayer._layers[0]);
+      expect(trailsLayer.layers).toEqual(trailsLayer._layers);
 
-      expect(trailsLayer.sources).toBe(trailsLayer._sources);
-      expect(trailsLayer.sourceId).toBe(Object.keys(trailsLayer._sources)[0]);
-      expect(trailsLayer.source).toBe(trailsLayer._sources[Object.keys(trailsLayer._sources)[0]]);
+      expect(trailsLayer.sources).toEqual(trailsLayer._sources);
+      expect(trailsLayer.sourceId).toEqual(Object.keys(trailsLayer._sources)[0]);
+      expect(trailsLayer.source).toEqual(trailsLayer._sources[Object.keys(trailsLayer._sources)[0]]);
     });
     test('`copyLayer` and `copySource` create deep copies of style data.', ({trailsLayer}) => {
       const sourceCopy = trailsLayer.copySource(trailsLayer.sourceId);
@@ -634,10 +660,10 @@ describe('Feature layer unit tests', () => {
       const customId = 'customSourceId';
       trailsLayer.setSourceId(trailsLayer.sourceId, customId);
 
-      expect(trailsLayer.sourceId).toBe(customId);
-      expect(trailsLayer.sources[customId]).toBe(trailsLayer.source);
+      expect(trailsLayer.sourceId).toEqual(customId);
+      expect(trailsLayer.sources[customId]).toEqual(trailsLayer.source);
 
-      expect(trailsLayer.layer.source).toBe(customId);
+      expect(trailsLayer.layer.source).toEqual(customId);
     });
     test('`setAttribution` sets the attribution of the specified source.', ({trailsLayer}) => {
       const customAttribution = 'User-provided custom attribution.';
@@ -705,10 +731,8 @@ describe('Works on a mock page with a `Map`',() => {
     });
 
     expect(Object.keys(mapStyle.sources).length).toBe(1);
-    expect(mapStyle.sources[Object.keys(mapStyle.sources)[0]].data).toEqual(getBlankFc()); // Blank FC since data is loaded dynamically
-
     expect(mapStyle.layers.length).toBe(1);
-    expect(mapStyle.layers[0].source).toBe(Object.keys(mapStyle.sources)[0]);
+    expect(mapStyle.layers[0].source).toEqual(Object.keys(mapStyle.sources)[0]); // Source ID set properly
   });
 
   test('`addSourcesTo` and `addLayersTo` add sources and layers to the maplibre map.', async ({setupPage}) => {
@@ -729,8 +753,6 @@ describe('Works on a mock page with a `Map`',() => {
       });
     });
     expect(Object.keys(mapStyle.sources).length).toBe(1);
-    expect(mapStyle.sources[Object.keys(mapStyle.sources)[0]].data).toEqual(getBlankFc());
-
     expect(mapStyle.layers.length).toBe(1);
     expect(mapStyle.layers[0].source).toBe(Object.keys(mapStyle.sources)[0]);
   });
@@ -752,8 +774,6 @@ describe('Works on a mock page with a `Map`',() => {
       });
     });
     expect(Object.keys(style.sources).length).toBe(1);
-    expect(style.sources[Object.keys(style.sources)[0]].data).toEqual(trailsMock.geoJSONRaw);
-
     expect(style.layers.length).toBe(1);
     expect(style.layers[0].source).toBe(Object.keys(style.sources)[0]);
   });
@@ -858,7 +878,7 @@ describe('Works on a mock page with a `Map`',() => {
   });
 
   // TODO
-  test('Works with native maplibre `addSource` and `addLayer` methods.', async ({setupPage}) => {
+  test('Works with native maplibre `addSource` and `addLayer` methods if map is set.', async ({setupPage}) => {
     const page = await setupPage('feature-layer.html');
     await page.waitForFunction(() => window.map && window.featureLayer);
 

--- a/test/FeatureLayer.test.ts
+++ b/test/FeatureLayer.test.ts
@@ -908,7 +908,7 @@ describe('Works on a mock page with a `Map`',() => {
     });
 
     expect(Object.keys(style.sources).length).toBe(1);
-    expect(style.sources[Object.keys(style.sources)[0]].data).toEqual(trailsMock.geoJSONRaw);
+    expect(style.sources[Object.keys(style.sources)[0]].data).toEqual(getBlankFc());
 
     expect(style.layers.length).toBe(1);
     expect(style.layers[0].source).toBe(Object.keys(style.sources)[0]);

--- a/test/FeatureLayer.test.ts
+++ b/test/FeatureLayer.test.ts
@@ -612,7 +612,7 @@ describe('Feature layer unit tests', () => {
     expect(layer2.sourceId).toEqual(trailsMock.layerDefinitionRaw.name);
   });
 
-  describe.skip('Methods inherited from HostedLayer work properly.', () => {
+  describe('Methods inherited from HostedLayer work properly.', () => {
     test('`layer`, `layers, `source`, `sources`, `sourceId` are read-only properties containing style data.', ({trailsLayer}) => {
       expect(trailsLayer.layer).toBe(trailsLayer._layers[0]);
       expect(trailsLayer.layers).toBe(trailsLayer._layers);
@@ -858,7 +858,7 @@ describe('Works on a mock page with a `Map`',() => {
   });
 
   // TODO
-  test.skip('Works with native maplibre `addSource` and `addLayer` methods.', async ({setupPage}) => {
+  test('Works with native maplibre `addSource` and `addLayer` methods.', async ({setupPage}) => {
     const page = await setupPage('feature-layer.html');
     await page.waitForFunction(() => window.map && window.featureLayer);
 

--- a/test/FeatureLayerSourceManager.test.ts
+++ b/test/FeatureLayerSourceManager.test.ts
@@ -28,7 +28,9 @@ const test = customTest.extend({
     const mockMap = {
       getSource: vi.fn(() => ({
         setData: vi.fn()
-      }))
+      })),
+      on: vi.fn(),
+      off: vi.fn(),
     };
     await use(mockMap);
   }
@@ -93,11 +95,16 @@ describe('Feature layer data source tests', () => {
   test('onAdd event triggers the load function.', async ({ map }) => {
     const manager = new FeatureLayerSourceManager(sourceId, trailsMock.layerUrl, trailsMock.layerDefinitionRaw, {});
 
-    const loadSpy = vi.spyOn(manager, '_load');
+    const loadSpy = vi.spyOn(manager, 'load').mockImplementation(vi.fn());
 
     manager.onAdd(map);
     expect(loadSpy).toHaveBeenCalled();
   });
+  // TODO
+  test('Adds a maplibre event listener that triggers loading when the correct source ID is added to map', async () => {
+
+  });
+  test('onAdd event removes the maplibre event listener trigger', async () => {});
 
   test('Accepts a layer definition in the constructor', async () => {
     const manager = new FeatureLayerSourceManager(sourceId, trailsMock.layerUrl, trailsMock.layerDefinitionRaw, {});
@@ -105,8 +112,10 @@ describe('Feature layer data source tests', () => {
     expect(manager.layerDefinition).toBe(trailsMock.layerDefinitionRaw);
   });
 
-  test('Load function tries to load via snapshot mode initially', async () => {
-    const manager = new FeatureLayerSourceManager(sourceId, trailsMock.layerUrl, trailsMock.layerDefinitionRaw, {});
+  test('Load function tries to load via snapshot mode initially', async ({mockMap}) => {
+    const manager = new FeatureLayerSourceManager(sourceId, trailsMock.layerUrl, trailsMock.layerDefinitionRaw, {
+      map: mockMap
+    });
 
     const exceedsLimitSpy = vi.spyOn(manager, '_checkIfExceedsLimit').mockImplementation(() => false);
     const snapshotSpy = vi.spyOn(manager, '_loadFeatureSnapshot').mockImplementation(() => getBlankFc());
@@ -118,7 +127,7 @@ describe('Feature layer data source tests', () => {
     expect(bindEventSpy).not.toHaveBeenCalled();
   });
 
-  test('Snapshot mode performs an initial exceedsLimit request using hardcoded values specific to each geometry type.', async () => {
+  test('Snapshot mode performs an initial exceedsLimit request using limit values specific to each geometry type.', async () => {
     const manager = new FeatureLayerSourceManager(sourceId, trailsMock.layerUrl, trailsMock.layerDefinitionRaw, {
       loadingMode: 'snapshot'
     });
@@ -135,8 +144,10 @@ describe('Feature layer data source tests', () => {
     expect(updateMapSpy).toHaveBeenCalled();
   });
 
-  test('Load function falls back to on-demand loading if the snapshot limit is exceeded.', async () => {
-    const manager = new FeatureLayerSourceManager(sourceId, trailsMock.layerUrl, trailsMock.layerDefinitionRaw, {});
+  test('Load function falls back to on-demand loading if the snapshot limit is exceeded.', async ({mockMap}) => {
+    const manager = new FeatureLayerSourceManager(sourceId, trailsMock.layerUrl, trailsMock.layerDefinitionRaw, {
+      map: mockMap
+    });
 
     const exceedsLimitSpy = vi.spyOn(manager, '_checkIfExceedsLimit').mockImplementation(() => true);
     vi.spyOn(manager, '_bindLoadFeaturesToMoveEndEvent').mockImplementation(() => {});
@@ -146,8 +157,10 @@ describe('Feature layer data source tests', () => {
     expect(onDemandSpy).toHaveBeenCalled();
   });
 
-  test('Load function falls back to on-demand loading if snapshot mode throws.', async () => {
-    const manager = new FeatureLayerSourceManager(sourceId, trailsMock.layerUrl, trailsMock.layerDefinitionRaw, {});
+  test('Load function falls back to on-demand loading if snapshot mode throws.', async ({mockMap}) => {
+    const manager = new FeatureLayerSourceManager(sourceId, trailsMock.layerUrl, trailsMock.layerDefinitionRaw, {
+      map: mockMap
+    });
 
     const exceedsLimitSpy = vi.spyOn(manager, '_checkIfExceedsLimit').mockImplementation(() => true);
     const setMaxExtentFromLayerExtentSpy = vi.spyOn(manager, '_setMaxExtentFromLayerExtent').mockImplementation(() => null);
@@ -162,21 +175,23 @@ describe('Feature layer data source tests', () => {
     expect(loadFeaturesOnDemandSpy).toHaveBeenCalled();
   });
 
-  test('If loadingMode parameter is set to snapshot, only tries snapshot mode and throws if limits are exceeded.', async () => {
+  test('If loadingMode parameter is set to snapshot, only tries snapshot mode and throws if limits are exceeded.', async ({mockMap}) => {
     const manager = new FeatureLayerSourceManager(sourceId, trailsMock.layerUrl, trailsMock.layerDefinitionRaw, {
-      loadingMode: 'snapshot'
+      loadingMode: 'snapshot',
+      map: mockMap
     });
     const exceedsLimitSpy = vi.spyOn(manager, '_checkIfExceedsLimit').mockImplementation(() => true);
     try {
       await manager.load();
     } catch (err) {
-      expect(err.message).toBe('Unable to load using snapshot mode: geometry limit exceeded.');
+      expect(err.message).toBe('Unable to load feature service using snapshot mode: Geometry limit exceeded.');
     }
   });
 
-  test('If loadingMode parameter is set to ondemand, only tries on-demand mode.', async () => {
+  test('If loadingMode parameter is set to ondemand, only tries on-demand mode.', async ({mockMap}) => {
     const manager = new FeatureLayerSourceManager(sourceId, trailsMock.layerUrl, trailsMock.layerDefinitionRaw, {
-      loadingMode: 'ondemand'
+      loadingMode: 'ondemand',
+      map: mockMap
     });
 
     const exceedsLimitSpy = vi.spyOn(manager, '_checkIfExceedsLimit').mockImplementation(() => true);
@@ -214,7 +229,7 @@ describe('Feature layer data source tests', () => {
       queryAllFeatures = importedQueryAllFeatures;
       queryFeatures = importedQueryFeatures;
     });
-    test.only('Loads data from a layer and uses it to update a MapLibre geojson source.', async ({mockMap}) => {
+    test('Loads data from a layer and uses it to update a MapLibre geojson source.', async ({mockMap}) => {
 
       queryAllFeatures = vi.fn().mockResolvedValue(trailsMock.geoJSONSmallRaw);
       queryFeatures = vi.fn().mockResolvedValue(trailsMock.exceedsLimitResponseRaw);
@@ -223,14 +238,14 @@ describe('Feature layer data source tests', () => {
       });
       manager.map = mockMap;
 
-      const updateMapSpy = vi.spyOn(manager, '_updateSourceData').mockImplementation(() => {return true});
+      const updateDataSpy = vi.spyOn(manager, '_updateSourceData').mockImplementation(() => {return true});
 
       await manager.load();
 
-      expect(updateMapSpy).toHaveBeenCalledWith(mockMap, trailsMock.geoJSONSmallRaw);
+      expect(updateDataSpy).toHaveBeenCalledWith(trailsMock.geoJSONSmallRaw, mockMap);
     });
 
-    test('Passes authentication to all snapshot mode REST JS requests.', async () => {
+    test('Passes authentication to all snapshot mode REST JS requests.', async ({mockMap}) => {
       queryAllFeatures = vi.fn().mockResolvedValue(trailsMock.geoJSONSmallRaw);
       queryFeatures = vi.fn().mockResolvedValue(trailsMock.exceedsLimitResponseRaw);
       const apiKey = "fake-api-key";
@@ -238,7 +253,8 @@ describe('Feature layer data source tests', () => {
       const apiKeyManager = { getToken: () => apiKey };
       const manager = new FeatureLayerSourceManager(sourceId, trailsMock.layerUrl, trailsMock.layerDefinitionRaw, {
         authentication: apiKeyManager,
-        loadingMode: 'snapshot'
+        loadingMode: 'snapshot',
+        map: mockMap
       });
 
       const updateMapSpy = vi.spyOn(manager, '_updateSourceData').mockImplementation(() => {return true});
@@ -249,7 +265,7 @@ describe('Feature layer data source tests', () => {
       expect(queryAllFeatures).toHaveBeenCalledWith(expect.objectContaining({authentication:apiKeyManager}));
     });
 
-    test('Passes the `query` parameter to snapshot REST JS requests.', async () => {
+    test('Passes the `query` parameter to snapshot REST JS requests.', async ({mockMap}) => {
       queryAllFeatures = vi.fn().mockResolvedValue(trailsMock.geoJSONSmallRaw);
       queryFeatures = vi.fn().mockResolvedValue(trailsMock.exceedsLimitResponseRaw);
 
@@ -259,7 +275,8 @@ describe('Feature layer data source tests', () => {
       }
 
       const manager = new FeatureLayerSourceManager(sourceId, trailsMock.layerUrl, trailsMock.layerDefinitionRaw, {
-        queryOptions: trailQuery
+        queryOptions: trailQuery,
+        map: mockMap
       });
 
       expect(manager._options.queryOptions).toEqual(trailQuery);

--- a/test/FeatureLayerSourceManager.test.ts
+++ b/test/FeatureLayerSourceManager.test.ts
@@ -100,11 +100,46 @@ describe('Feature layer data source tests', () => {
     manager.onAdd(map);
     expect(loadSpy).toHaveBeenCalled();
   });
-  // TODO
-  test('Adds a maplibre event listener that triggers loading when the correct source ID is added to map', async () => {
+  test('Adds a maplibre event listener that triggers loading when the correct source ID is added to map', async ({mockMap}) => {
+    const manager = new FeatureLayerSourceManager(sourceId, trailsMock.layerUrl, trailsMock.layerDefinitionRaw, {
+      map:mockMap
+    });
 
+    const onAddSpy = vi.spyOn(manager, 'onAdd').mockImplementation(vi.fn());
+
+    expect(mockMap.on).toHaveBeenCalledWith('sourcedataloading', manager._onAddEvent);
+
+    // mock trigger event from maplibre map
+    manager._triggerOnAdd({sourceId:manager.geojsonSourceId}, manager.geojsonSourceId);
+
+    expect(onAddSpy).toHaveBeenCalled();
   });
-  test('onAdd event removes the maplibre event listener trigger', async () => {});
+  test('onAdd event removes the maplibre event listener trigger', async ({mockMap}) => {
+        const manager = new FeatureLayerSourceManager(sourceId, trailsMock.layerUrl, trailsMock.layerDefinitionRaw, {
+      map:mockMap
+    });
+
+    const onAddSpy = vi.spyOn(manager, 'onAdd');
+    const loadSpy = vi.spyOn(manager, 'load').mockImplementation(vi.fn());
+
+    // mock trigger event from maplibre map
+    manager._triggerOnAdd({sourceId:manager.geojsonSourceId}, manager.geojsonSourceId);
+
+    expect(onAddSpy).toHaveBeenCalled();
+
+    expect(mockMap.off).toHaveBeenCalledWith('sourcedataloading', manager._onAddEvent);
+  });
+
+  test('Throws if load is called directly without providing a map.', async ({mockMap}) => {
+    const manager = new FeatureLayerSourceManager(sourceId, trailsMock.layerUrl, trailsMock.layerDefinitionRaw, {});
+
+    try {
+      await manager.load();
+    }
+    catch (err) {
+      expect(err.message).toBe('Feature service loading requires a map.')
+    }
+  });
 
   test('Accepts a layer definition in the constructor', async () => {
     const manager = new FeatureLayerSourceManager(sourceId, trailsMock.layerUrl, trailsMock.layerDefinitionRaw, {});
@@ -207,20 +242,38 @@ describe('Feature layer data source tests', () => {
     expect(loadFeaturesOnDemandSpy).toHaveBeenCalled();
   });
 
-  // TODO
-  describe('General loading tests', async () => {
 
-    test('If a map is provided in constructor, triggers loading from an event listener when sourcedataloading event fires.', async () => {});
-    test('If a map is not provided in constructor, triggers loading when onAdd is called.', async () => {});
+  test('_updateSourceData sets the data of the parent feature layer internally.', async ({mockMap}) => {
+    const setDataCallback = vi.fn();
+    const manager = new FeatureLayerSourceManager(sourceId, trailsMock.layerUrl, trailsMock.layerDefinitionRaw, {
+      loadingMode: 'snapshot',
+      map: mockMap,
+      callback: setDataCallback
+    });
 
-    test('Throws if load is called directly without providing a map.', async () => {});
+    expect(manager._setDataCallback).toBe(setDataCallback);
 
+    const exceedsLimitSpy = vi.spyOn(manager, '_checkIfExceedsLimit').mockImplementation(() => false);
+    const loadFeatureSnapshotSpy = vi.spyOn(manager, '_loadFeatureSnapshot').mockImplementation(() => {});
 
+    await manager.load();
+    expect(setDataCallback).toHaveBeenCalled();
 
-    test('_updateSourceData sets the data of the source internally.', async () => {});
-    test('_updateSourceData sets the data of the source on the associated map.', async () => {});
-    test('')
-  })
+  });
+  test('_updateSourceData sets the data of the source on the associated map.', async ({mockMap}) => {
+    const manager = new FeatureLayerSourceManager(sourceId, trailsMock.layerUrl, trailsMock.layerDefinitionRaw, {
+      loadingMode: 'snapshot',
+      map: mockMap,
+    });
+
+    const exceedsLimitSpy = vi.spyOn(manager, '_checkIfExceedsLimit').mockImplementation(() => false);
+    const loadFeatureSnapshotSpy = vi.spyOn(manager, '_loadFeatureSnapshot').mockImplementation(() => {return {}});
+    const updateSpy = vi.spyOn(manager, '_updateSourceData');
+
+    await manager.load();
+    expect(updateSpy).toHaveBeenCalledWith({}, mockMap);
+    expect(mockMap.getSource).toHaveBeenCalledWith(manager.geojsonSourceId);
+  });
 
   describe('Snapshot mode loading tests', async () => {
     const importedQueryFeatures = queryFeatures;

--- a/test/FeatureLayerSourceManager.test.ts
+++ b/test/FeatureLayerSourceManager.test.ts
@@ -24,6 +24,14 @@ const { multiLayerMock, trailsMock } = featureMocks;
 
 const test = customTest.extend({
 
+  mockMap: async ({}, use) => {
+    const mockMap = {
+      getSource: vi.fn(() => ({
+        setData: vi.fn()
+      }))
+    };
+    await use(mockMap);
+  }
   // mockMap: async ({}, use) => {
   //   const mapDiv = document.createElement('div');
 
@@ -104,7 +112,7 @@ describe('Feature layer data source tests', () => {
     const snapshotSpy = vi.spyOn(manager, '_loadFeatureSnapshot').mockImplementation(() => getBlankFc());
     const bindEventSpy = vi.spyOn(manager, '_bindLoadFeaturesToMoveEndEvent');
     const updateMapSpy = vi.spyOn(manager, '_updateSourceData').mockImplementation(() => true);
-    await manager._load();
+    await manager.load();
 
     expect(snapshotSpy).toHaveBeenCalled();
     expect(bindEventSpy).not.toHaveBeenCalled();
@@ -120,7 +128,7 @@ describe('Feature layer data source tests', () => {
     const loadFeatureSnapshotSpy = vi.spyOn(manager, '_loadFeatureSnapshot').mockImplementation(() => {});
     const updateMapSpy = vi.spyOn(manager, '_updateSourceData').mockImplementation(() => null);
 
-    await manager._load();
+    await manager.load();
     // check if exceeds limit was called with both args with the hardcoded geometry limits for the trails layer (polygon)
     expect(exceedsLimitSpy).toHaveBeenCalledWith(expect.objectContaining({}), { maxVertexCount:250000, maxRecordCount:8000 });
     expect(loadFeatureSnapshotSpy).toHaveBeenCalled();
@@ -134,7 +142,7 @@ describe('Feature layer data source tests', () => {
     vi.spyOn(manager, '_bindLoadFeaturesToMoveEndEvent').mockImplementation(() => {});
     const onDemandSpy = vi.spyOn(manager, '_loadFeaturesOnDemand').mockImplementation(() => {return true});
 
-    await manager._load();
+    await manager.load();
     expect(onDemandSpy).toHaveBeenCalled();
   });
 
@@ -147,7 +155,7 @@ describe('Feature layer data source tests', () => {
     const clearTilesSpy = vi.spyOn(manager, '_clearTiles').mockImplementation(() => null);
     const loadFeaturesOnDemandSpy = vi.spyOn(manager, '_loadFeaturesOnDemand').mockImplementation(() => Promise.resolve(null));
 
-    await manager._load();
+    await manager.load();
     expect(setMaxExtentFromLayerExtentSpy).toHaveBeenCalled();
     expect(bindLoadFeaturesToMoveEndEventSpy).toHaveBeenCalled();
     expect(clearTilesSpy).toHaveBeenCalled();
@@ -160,7 +168,7 @@ describe('Feature layer data source tests', () => {
     });
     const exceedsLimitSpy = vi.spyOn(manager, '_checkIfExceedsLimit').mockImplementation(() => true);
     try {
-      await manager._load();
+      await manager.load();
     } catch (err) {
       expect(err.message).toBe('Unable to load using snapshot mode: geometry limit exceeded.');
     }
@@ -177,12 +185,27 @@ describe('Feature layer data source tests', () => {
     const clearTilesSpy = vi.spyOn(manager, '_clearTiles').mockImplementation(() => null);
     const loadFeaturesOnDemandSpy = vi.spyOn(manager, '_loadFeaturesOnDemand').mockImplementation(() => Promise.resolve(null));
 
-    await manager._load();
+    await manager.load();
     expect(useServiceBoundsSpy).toHaveBeenCalled();
     expect(bindLoadFeaturesToMoveEndEventSpy).toHaveBeenCalled();
     expect(clearTilesSpy).toHaveBeenCalled();
     expect(loadFeaturesOnDemandSpy).toHaveBeenCalled();
   });
+
+  // TODO
+  describe('General loading tests', async () => {
+
+    test('If a map is provided in constructor, triggers loading from an event listener when sourcedataloading event fires.', async () => {});
+    test('If a map is not provided in constructor, triggers loading when onAdd is called.', async () => {});
+
+    test('Throws if load is called directly without providing a map.', async () => {});
+
+
+
+    test('_updateSourceData sets the data of the source internally.', async () => {});
+    test('_updateSourceData sets the data of the source on the associated map.', async () => {});
+    test('')
+  })
 
   describe('Snapshot mode loading tests', async () => {
     const importedQueryFeatures = queryFeatures;
@@ -191,12 +214,8 @@ describe('Feature layer data source tests', () => {
       queryAllFeatures = importedQueryAllFeatures;
       queryFeatures = importedQueryFeatures;
     });
-    test('Loads data from a layer and uses it to update a MapLibre geojson source.', async () => {
-      const mockMap = {
-        getSource: vi.fn(() => ({
-          setData: vi.fn()
-        }))
-      };
+    test.only('Loads data from a layer and uses it to update a MapLibre geojson source.', async ({mockMap}) => {
+
       queryAllFeatures = vi.fn().mockResolvedValue(trailsMock.geoJSONSmallRaw);
       queryFeatures = vi.fn().mockResolvedValue(trailsMock.exceedsLimitResponseRaw);
       const manager = new FeatureLayerSourceManager(sourceId, trailsMock.layerUrl, trailsMock.layerDefinitionRaw, {
@@ -206,7 +225,7 @@ describe('Feature layer data source tests', () => {
 
       const updateMapSpy = vi.spyOn(manager, '_updateSourceData').mockImplementation(() => {return true});
 
-      await manager._load();
+      await manager.load();
 
       expect(updateMapSpy).toHaveBeenCalledWith(mockMap, trailsMock.geoJSONSmallRaw);
     });
@@ -224,7 +243,7 @@ describe('Feature layer data source tests', () => {
 
       const updateMapSpy = vi.spyOn(manager, '_updateSourceData').mockImplementation(() => {return true});
 
-      await manager._load();
+      await manager.load();
 
       expect(queryFeatures).toHaveBeenCalledWith(expect.objectContaining({authentication:apiKeyManager}));
       expect(queryAllFeatures).toHaveBeenCalledWith(expect.objectContaining({authentication:apiKeyManager}));
@@ -246,7 +265,7 @@ describe('Feature layer data source tests', () => {
       expect(manager._options.queryOptions).toEqual(trailQuery);
 
       const updateMapSpy = vi.spyOn(manager, '_updateSourceData').mockImplementation(() => {return true});
-      await manager._load();
+      await manager.load();
 
       expect(queryAllFeatures).toHaveBeenCalledWith(expect.objectContaining(trailQuery));
     });

--- a/test/mock/pages/feature-layer.html
+++ b/test/mock/pages/feature-layer.html
@@ -29,7 +29,7 @@
     const layerUrlTrails = 'https://services3.arcgis.com/GVgbJbqm8hXASVYi/arcgis/rest/services/Trails/FeatureServer/0';
     const featureLayer = new maplibreArcGIS.FeatureLayer({
       url:layerUrlTrails,
-      _loadingMode:'ondemand'
+      loadingMode:'ondemand'
     });
 
     window.map = map;

--- a/test/mock/pages/feature-layer.html
+++ b/test/mock/pages/feature-layer.html
@@ -28,7 +28,8 @@
 
     const layerUrlTrails = 'https://services3.arcgis.com/GVgbJbqm8hXASVYi/arcgis/rest/services/Trails/FeatureServer/0';
     const featureLayer = new maplibreArcGIS.FeatureLayer({
-      url:layerUrlTrails
+      url:layerUrlTrails,
+      _loadingMode:'ondemand'
     });
 
     window.map = map;


### PR DESCRIPTION
Refactor layer loading for feature layer and vector tile layer APIs.

* Added passthrough for maplibre options to `addSourcesTo`, `addLayersTo`, `addSourcesAndLayersTo`.
* Added new methods `addSourceTo`, `addLayersTo` that accept maplibre options.
* Added option to pass `map` to constructor of hosted layer, for use with feature layer on-demand loading mode.
* Added `setMap` method to hosted layer, for setting the associated maplibre map.
* Feature layer: Reverted change in loading behavior that caused snapshot mode to not be awaited during initialization.
* Feature layer: Added new warning messages to reflect requirements of on-demand loading mode.