### PR TITLE
Fix path for TypeScript type definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,8 @@
   "exports": {
     ".": {
       "import": "./dist/esm/maplibre-arcgis.min.js",
-      "require": "./dist/umd/maplibre-arcgis.min.js"
+      "require": "./dist/umd/maplibre-arcgis.min.js",
+      "types": "./dist/esm/types/src/MaplibreArcGIS.d.ts"
     },
     "./package.json": "./package.json"
   },

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
   "main": "dist/umd/maplibre-arcgis.min.js",
   "module": "dist/esm/maplibre-arcgis.min.js",
   "unpkg": "dist/umd/maplibre-arcgis.min.js",
-  "types": "dist/esm/src/MaplibreArcGIS.d.ts",
+  "types": "dist/esm/types/src/MaplibreArcGIS.d.ts",
   "exports": {
     ".": {
       "import": "./dist/esm/maplibre-arcgis.min.js",


### PR DESCRIPTION
Currently, the typescript types in the published package are not working because the `types` field in the `package.json` is pointing to the wrong path.